### PR TITLE
Add unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ stella_save.f90
 *.py~
 
 externals/pFUnit_build
+unit_tests
+tests/unit/*.F90

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ stella_save.f90
 *.ini
 *.pickle
 *.py~
+
+externals/pFUnit_build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "externals/pFUnit"]
+	path = externals/pFUnit
+	url = git@github.com:Goddard-Fortran-Ecosystem/pFUnit.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "externals/pFUnit"]
 	path = externals/pFUnit
-	url = git@github.com:Goddard-Fortran-Ecosystem/pFUnit.git
+	url = https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,14 @@ sinclude Makefile.local
 
 #############################################################################
 
+# Record the top level path. Note we don't just use $(PWD) as this
+# resolves to the directory from which make was invoked. The approach
+# taken here ensures that GK_HEAD_DIR is the location of this
+# Makefile. Note the realpath call removes the trailing slash so
+# later we need to add a slash if we want to address subdirectories
+GK_THIS_MAKEFILE := $(abspath $(lastword $(MAKEFILE_LIST)))
+GK_HEAD_DIR := $(realpath $(dir $(GK_THIS_MAKEFILE)))
+
 export F90FLAGS
 export NETCDF_INC
 export NETCDF_LIB
@@ -309,6 +317,8 @@ F90FROMFPP = $(patsubst %.fpp,%.f90,$(notdir $(wildcard *.fpp */*.fpp)))
 	$(FC) $(F90FLAGS) $(INC_FLAGS) -c $<
 .fpp.f90:
 	$(CPP) $(CPPFLAGS) $< $@
+.F90.o:
+	$(FC) $(F90FLAGS) $(CPPFLAGS) $(INC_FLAGS) -c $<
 .c.o:
 	$(CC) $(CFLAGS) -c $<
 
@@ -331,6 +341,13 @@ all: $(.DEFAULT_GOAL)
 include $(DEPEND)
 
 sinclude Makefile.target_$(GK_PROJECT)
+
+# Include unit test makefile, empty target so Make doesn't attempt to
+# build the file
+tests/unit/Makefile:
+include tests/unit/Makefile
+
+check: check-unit
 
 ############################################################### SPECIAL RULES
 

--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,14 @@ PETSC_LIB ?=
 PETSC_INC ?=
 LIBSTELL_LIB ?=
 
+# Record the top level path. Note we don't just use $(PWD) as this
+# resolves to the directory from which make was invoked. The approach
+# taken here ensures that GK_HEAD_DIR is the location of this
+# Makefile. Note the realpath call removes the trailing slash so
+# later we need to add a slash if we want to address subdirectories
+GK_THIS_MAKEFILE := $(abspath $(lastword $(MAKEFILE_LIST)))
+GK_HEAD_DIR := $(realpath $(dir $(GK_THIS_MAKEFILE)))
+
 ######################################################### PLATFORM DEPENDENCE
 
 # compile mode switches (DEBUG, TEST, OPT, STATIC, DBLE)
@@ -153,14 +161,6 @@ include Makefile.$(GK_SYSTEM)
 sinclude Makefile.local
 
 #############################################################################
-
-# Record the top level path. Note we don't just use $(PWD) as this
-# resolves to the directory from which make was invoked. The approach
-# taken here ensures that GK_HEAD_DIR is the location of this
-# Makefile. Note the realpath call removes the trailing slash so
-# later we need to add a slash if we want to address subdirectories
-GK_THIS_MAKEFILE := $(abspath $(lastword $(MAKEFILE_LIST)))
-GK_HEAD_DIR := $(realpath $(dir $(GK_THIS_MAKEFILE)))
 
 export F90FLAGS
 export NETCDF_INC

--- a/scripts/build_pfunit
+++ b/scripts/build_pfunit
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# Fail immediately if anything goes wrong
+set -e
+
+# Error codes
+error_cmake_not_available=1
+error_wrong_version_numer=2
+error_bad_arguments=3
+
+# Some default arguments
+
+# Should pFUnit use MPI
+pfunit_use_mpi="YES"
+
+# Which major version of pfunit are we using
+# Version 4+ needs very recent compilers
+pfunit_version_major=4
+
+# Number of make jobs to use (i.e. argument to `make -j N`)
+make_jobs=1
+
+# Locations of various things
+stella_directory=$(pwd)
+externals_directory="${stella_directory}/externals"
+pfunit_directory="${externals_directory}/pFUnit"
+pfunit_version_directory="${externals_directory}/pFUnit-${pfunit_version}"
+pfunit_build_directory="${externals_directory}/pFUnit_build"
+pfunit_install_directory="${externals_directory}/pFUnit_build/install"
+
+function usage {
+    echo "usage: ${0##*/} [-m] [-v ARG] [-b ARG] [-i ARG] [-j ARG] [-r] [-h|--help]"
+    echo "A helper script for building pFUnit for STELLA"
+    echo ""
+    echo "Arguments:"
+    echo "  -m              Disable MPI"
+    echo "  -v 3|4          Set which major version of pFUnit to use"
+    echo "  -b BUILD_DIR    Directory to build pFUnit in"
+    echo "  -i INSTALL_DIR  Directory to install pFUnit in"
+    echo "  -j N            Number of make jobs to use (default: 1)"
+    echo "  -r              Remove the pFUnit installation directory"
+    echo "  -h, --help      Print this help and exit"
+}
+
+# These arguments need to be first
+if [[ "$1" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+while getopts ":mv:b:i:hrj:" OPT; do
+    case $OPT in
+        m )
+            echo "Disabling MPI"
+            echo "WARNING: currently some pFUnit tests require MPI and this might not work"
+            pfunit_use_mpi="NO"
+            ;;
+        v )
+            if [[ ! "$OPTARG" -eq 3 && ! "$OPTARG" -eq 4 ]]; then
+                echo "pFUnit major version number must be either '3' or '4'" 1>&2
+                exit $error_wrong_version_numer
+            fi
+            echo "Using pFUnit major version $OPTARG"
+            pfunit_version_major="$OPTARG"
+            ;;
+        b )
+            echo "Building pFUnit in $OPTARG"
+            pfunit_build_directory="$OPTARG"
+            ;;
+        i )
+            echo "Installing pFUnit in $OPTARG"
+            pfunit_install_directory="$OPTARG"
+            ;;
+        r )
+            remove_installation_directory=true
+            ;;
+        j )
+            make_jobs="$OPTARG"
+            ;;
+        h )
+            usage
+            exit 0
+            ;;
+        \* )
+           usage
+           exit $error_bad_arguments
+           ;;
+    esac
+done
+shift $(( OPTIND - 1 ))
+OPTIND=1
+
+if [[ -n $remove_installation_directory ]]; then
+    echo "Removing pFUnit installation directory $pfunit_install_directory"
+    rm -rf "$pfunit_install_directory"
+    exit 0
+fi
+
+if [[ ${pfunit_version_major} == 3 ]]; then
+    pfunit_url="https://github.com/Goddard-Fortran-Ecosystem/pFUnit/archive/3.3.3.tar.gz"
+    pfunit_version="3.3.3"
+    pfunit_openmp_flag="-DOPENMP=NO"
+else
+    pfunit_url="https://github.com/Goddard-Fortran-Ecosystem/pFUnit/releases/download/v4.2.1/pFUnit-4.2.1.tar.gz"
+    pfunit_version="4.2.1"
+    pfunit_openmp_flag="-DSKIP_OPENMP=YES"
+fi
+
+# What to rename the tarball to
+pfunit_downloaded_file="pFUnit-${pfunit_version}.tar.gz"
+
+# If pFUnit is already installed, we don't need to go any further and can exit cleanly
+if [[ -d ${pfunit_install_directory} ]]; then
+    echo "pFUnit installation directory \"${pfunit_install_directory}\" already exists, nothing to do"
+    exit 0
+fi
+
+# Check that CMake is available
+if [[ ! $(command -v cmake) ]]; then
+    echo "CMake is required to compile and install pfUnit"
+    echo "Please install CMake either from your system package manager, or by running:"
+    echo ""
+    echo "    pip install --user cmake"
+    echo ""
+    echo "This will install CMake into '~/.local/bin' -- you may need to add this to"
+    echo "your PATH environment variable"
+    exit ${error_cmake_not_available}
+fi
+
+# Check if we're in a git repo and, if so, that the pFUnit submodule is up-to-date
+if [[ ! $(git rev-parse --git-dir >/dev/null 2>&1 || [[ -d ${stella_directory}/.git ]]) ]]; then
+    echo "Making sure pFUnit submodule is up-to-date"
+    git submodule update --init --recursive externals/pFUnit
+fi
+
+# If we're not in a git repo and the pFUnit submodule isn't there, best download it
+if [[ ! -d ${pfunit_directory} ]]; then
+    echo "pFUnit submodule not availabe downloading pFUnit tarball"
+    cd ${externals_directory}
+    wget ${pfunit_url} -O ${pfunit_downloaded_file}
+    tar xf ${pfunit_downloaded_file}
+
+    # We want to build from the versioned directory
+    pfunit_directory=${pfunit_version_directory}
+fi
+
+mkdir -p ${pfunit_build_directory}
+
+cd ${pfunit_build_directory}
+echo "Building pFUnit version ${pfunit_version_major} from ${pfunit_directory}"
+cmake ${pfunit_directory} -DMPI=${pfunit_use_mpi} ${pfunit_openmp_flag} \
+      -DCMAKE_INSTALL_PREFIX=${pfunit_install_directory} \
+      -DMPIEXEC_EXECUTABLE=$(which mpiexec)
+make -j "$make_jobs"
+echo "Install pFUnit to ${pfunit_install_directory}"
+make install
+
+echo "Please use build stella with the following variables:"
+echo "    PFUNIT_VERSION_MAJOR=${pfunit_version_major}"
+echo "    PFUNIT_DIR=${pfunit_install_directory}"

--- a/scripts/ci_build_and_run.sh
+++ b/scripts/ci_build_and_run.sh
@@ -4,3 +4,6 @@ set -ex
 
 export GK_SYSTEM=gnu_ubuntu
 make -I Makefiles -j2
+
+make -I Makefiles build-pfunit-library
+make -I Makefiles check-unit

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -17,7 +17,10 @@ PFUNIT_ERROR:=pfunit.error
 CPPFLAGS += -DPFUNIT_VERSION_MAJOR=$(PFUNIT_VERSION_MAJOR)
 
 ifeq ($(PFUNIT_VERSION_MAJOR),4)
-  include $(PFUNIT_DIR)/include/PFUNIT.mk
+# Build pFUnit if we can't include the makefile
+$(PFUNIT_DIR)/include/PFUNIT.mk: build-pfunit-library
+
+  sinclude $(PFUNIT_DIR)/include/PFUNIT.mk
   PFUNIT_MOD := pfunit
   PFUNIT_PREPROCESSOR ?= $(PFUNIT_BIN_DIR)/funitproc
   PFUNIT_INC := -I$(PFUNIT_INCLUDE_DIR)

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -1,0 +1,128 @@
+###############################################################
+# Variables
+
+PFUNIT_TEST_DIR = $(GK_HEAD_DIR)/tests/unit
+PFUNIT_NPROC = 4
+
+# Default major version of pFUnit
+# Versions 3 and 4 require different flags, etc.
+PFUNIT_VERSION_MAJOR ?= 4
+# Installation directory of pFUnit
+# Default is the directory where `scripts/build_pfunit` puts it
+PFUNIT_DIR ?= $(GK_HEAD_DIR)/externals/pFUnit_build/install
+
+PFUNIT_LOG:=pfunit.log
+PFUNIT_ERROR:=pfunit.error
+
+CPPFLAGS += -DPFUNIT_VERSION_MAJOR=$(PFUNIT_VERSION_MAJOR)
+
+ifeq ($(PFUNIT_VERSION_MAJOR),4)
+  include $(PFUNIT_DIR)/include/PFUNIT.mk
+  PFUNIT_MOD := pfunit
+  PFUNIT_PREPROCESSOR ?= $(PFUNIT_BIN_DIR)/funitproc
+  PFUNIT_INC := -I$(PFUNIT_INCLUDE_DIR)
+  PFUNIT_LIB := -L$(PFUNIT_TOP_DIR)/lib -lpfunit -lfunit $(FARGPARSE_LIBRARIES)
+  F90FLAGS += $(PFUNIT_EXTRA_FFLAGS)
+else
+  PFUNIT_MOD := pfunit_mod
+  PFUNIT_PREPROCESSOR ?= $(PFUNIT_DIR)/bin/pFUnitParser.py
+  PFUNIT_INC := -I$(PFUNIT_DIR)/mod
+  PFUNIT_LIB := -L$(PFUNIT_DIR)/lib -lpfunit
+endif
+
+CPPFLAGS += -DPFUNIT_MOD=$(PFUNIT_MOD)
+
+PFUNIT_TEST_PATH :=.
+
+STELLA_OBJS := $(filter-out stella.o, $(stella_mod))
+
+PFUNIT_TESTS:= $(shell find $(PFUNIT_TEST_DIR) -name '[^.\#]*.pf')
+
+PFUNIT_OBJS := $(PFUNIT_TESTS:.pf=.o)
+PFUNIT_INTERMEDIATES := $(PFUNIT_TESTS:.pf=.F90)
+PFUNIT_DRIVER := $(PFUNIT_DIR)/include/driver.F90
+PFUNIT_TEST_LIST := $(PFUNIT_TEST_DIR)/testSuites.inc
+
+.INTERMEDIATE: $(PFUNIT_INTERMEDIATES)
+
+###############################################################
+# pFUnit library
+
+.PHONY: build-pfunit-library check-pfunit-install clean-pfunit-library
+
+build-pfunit-library:
+	@echo "Building pFUnit in default location: $(GK_HEAD_DIR)/externals/pFUnit_build/install"
+ifdef USE_MPI
+	@scripts/build_pfunit -v ${PFUNIT_VERSION_MAJOR}
+else
+	@scripts/build_pfunit -v ${PFUNIT_VERSION_MAJOR} -m
+endif
+
+check-pfunit-install:
+ifeq ("$(wildcard $(PFUNIT_PREPROCESSOR))","")
+	$(error pFUnit files not found. Make sure pFUnit is installed and PFUNIT_DIR is set to its location)
+endif
+
+clean-pfunit-library:
+	@echo "Removing pFUnit library"
+	@scripts/build_pfunit -r
+
+distclean: clean-pfunit-library
+
+###############################################################
+# Test suite
+
+%.o : %.pf
+	$(PFUNIT_PREPROCESSOR) $< $(basename $<).F90
+ifdef ONE_STEP_PP
+	$(QUIETSYM)$(FC) $(FPPFLAGS) $(F90FLAGS) -c $(basename $<).F90 $(PFUNIT_INC) -I$(GK_HEAD_DIR) -o $@
+else
+	$(QUIETSYM)$(CPP) $(FPPFLAGS) $(basename $<).F90 -o $(basename $<).f90
+	$(QUIETSYM)$(FC) $(F90FLAGS) -c $(basename $<).f90 $(PFUNIT_INC) -I$(GK_HEAD_DIR) -o $@
+endif
+
+$(PFUNIT_DRIVER): $(PFUNIT_TEST_LIST)
+	@touch $(PFUNIT_DRIVER)
+
+$(PFUNIT_OBJS): $(STELLA_OBJS)
+
+# The test suite executable recipe
+unit_tests: $(PFUNIT_OBJS) $(PFUNIT_DRIVER) $(STELLA_OBJS)
+	@echo "Compiling: pFUnit tests"
+	$(FC) -o $@ $^ -DUSE_MPI=YES $(PFUNIT_INC) $(PFUNIT_LIB) -I. $(SIMPLEDATAIO_LIB_ABS) $(LIBS) $(F90FLAGS) -I$(PFUNIT_TEST_DIR) -D_TEST_SUITES='"$(PFUNIT_TEST_LIST)"'
+
+check-unit: check-pfunit-install unit_tests
+	@echo "Running: pFUnit tests"
+	@mpirun -np $(PFUNIT_NPROC) $(PFUNIT_TEST_PATH)/unit_tests
+
+###############################################################
+# Coverage
+
+.PHONY: coverage pfunit-coverage run-gcov
+
+coverage:
+	gcov *.f90
+
+ifndef USE_GCOV
+coverage-pfunit: coverage_gcov_fail
+coverage_gcov_fail:
+	$(error Cannot make coverage-pfunit as USE_GCOV undefined. Rebuild everything with USE_GCOV=on)
+else
+coverage-pfunit: stella unit_tests coverage
+	mkdir -p coverage-pfunit
+	mv *.gcov coverage-pfunit/. || echo "Couldn't move generated gcov files to coverage-pfunit. This is likely because gcov files not found in ${GK_HEAD_DIR}."
+endif
+
+###############################################################
+# Clean up
+
+.PHONY: clean-unit
+
+clean-unit:
+	@echo "Cleaning pFUnit tests"
+	$(RM) unit_tests $(PFUNIT_TEST_DIR)/*.o $(PFUNIT_TEST_DIR)/*.mod \
+      $(PFUNIT_TEST_DIR)/*~ $(PFUNIT_TEST_DIR)/*.gcov $(PFUNIT_TEST_DIR)/*.gcda \
+      $(PFUNIT_TEST_DIR)/*.gcno $(PFUNIT_TEST_DIR)/*.log $(PFUNIT_TEST_DIR)/*.error \
+      $(PFUNIT_OBJS) $(PFUNIT_INTERMEDIATES) ./test_*mod ./wraptest_*mod
+
+clean: clean-unit

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -17,9 +17,6 @@ PFUNIT_ERROR:=pfunit.error
 CPPFLAGS += -DPFUNIT_VERSION_MAJOR=$(PFUNIT_VERSION_MAJOR)
 
 ifeq ($(PFUNIT_VERSION_MAJOR),4)
-# Build pFUnit if we can't include the makefile
-$(PFUNIT_DIR)/include/PFUNIT.mk: build-pfunit-library
-
   sinclude $(PFUNIT_DIR)/include/PFUNIT.mk
   PFUNIT_MOD := pfunit
   PFUNIT_PREPROCESSOR ?= $(PFUNIT_BIN_DIR)/funitproc

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -9,7 +9,7 @@ PFUNIT_NPROC = 4
 PFUNIT_VERSION_MAJOR ?= 4
 # Installation directory of pFUnit
 # Default is the directory where `scripts/build_pfunit` puts it
-PFUNIT_DIR ?= $(GK_HEAD_DIR)/externals/pFUnit_build/install
+PFUNIT_DIR ?= $(GK_HEAD_DIR)/externals/pFUnit_build/install/PFUNIT-4.2
 
 PFUNIT_LOG:=pfunit.log
 PFUNIT_ERROR:=pfunit.error

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -60,7 +60,7 @@ endif
 
 check-pfunit-install:
 ifeq ("$(wildcard $(PFUNIT_PREPROCESSOR))","")
-	$(error pFUnit files not found. Make sure pFUnit is installed and PFUNIT_DIR is set to its location)
+	$(error Could not find $(PFUNIT_PREPROCESSOR). Make sure pFUnit is installed and PFUNIT_DIR ($(PFUNIT_DIR)) is set to the current location)
 endif
 
 clean-pfunit-library:

--- a/tests/unit/testSuites.inc
+++ b/tests/unit/testSuites.inc
@@ -1,0 +1,1 @@
+ADD_TEST_SUITE(test_simple_mod_suite)

--- a/tests/unit/test_simple.pf
+++ b/tests/unit/test_simple.pf
@@ -1,0 +1,12 @@
+! This is a very simple test module to demonstrate the test suite is
+! working. This will be removed as soon as we have some actually
+! useful tests
+module test_simple_mod
+  use funit
+  implicit none
+contains
+  @test
+  subroutine test_always_true
+    @assertTrue(.true.)
+  end subroutine test_always_true
+end module test_simple_mod

--- a/tests/unit/writing_tests.md
+++ b/tests/unit/writing_tests.md
@@ -1,0 +1,462 @@
+---
+title: Writing Tests
+---
+
+[TOC]
+
+This document will take you through writing a new [pFUnit][pfunit]
+test, detailing some of the pitfalls and things to be aware of.
+
+## Basic structure of a test
+
+pFUnit can automatically detect and run new tests added to the test suite. In order to do
+this, it uses a custom preprocessor to convert the `.pf` files to `.F90` which are then
+compiled by the Fortran compiler as usual. We do also need to tell pFUnit about new files
+however, and these are listed in `tests/pfunit_tests/testSuites.inc`.
+
+A very simple pFUnit test for stella looks something like this:
+
+`my_tests.pf`:
+
+```
+module test_basic_mod
+  use PFUNIT_MOD
+  implicit none
+
+contains
+  @test
+  subroutine test_addition
+    @assertEqual(4, 2 + 2)
+  end subroutine test_addition
+end module test_basic_mod
+```
+
+`testSuites.inc`:
+
+```
+ADD_TEST_SUITE(test_basic_mod_suite)
+```
+
+Note that the module name has an additional `_suite` appended in `testSuites.inc`.
+
+Let's break down the test module line by line:
+
+```
+module test_basic_mod
+```
+
+The exact name isn't important, but in the stella tests, we prefer the naming convention
+`test_<stella module name>_mod`; for example: `test_leq_mod`, or `test_stella_time_mod`.
+
+```
+  use PFUNIT_MOD
+```
+
+After the `.pf` to `.F90` conversion step, the test module will use various functions and
+types from the pFUnit module, so we `use` the entire module.
+
+The all-caps is important here: we currently support using either pFUnit 3.x or 4.x, which
+use different module names. We preprocess the resulting `.F90` to replace `PFUNIT_MOD`
+with the correct module name.
+
+```
+  implicit none
+  
+contains
+```
+
+In this basic test module we just have the one test procedure, but we could declare
+module-level parameters here. For example, you may wish to set a `parameter` defining a
+tolerance for equalities.
+
+```
+  @test
+  subroutine test_addition
+```
+
+The `@test` is a pFUnit directive declaring the immediately following subroutine as a test
+to be run automatically. The subroutine name is not important, but we prefer the naming
+convention of a `test_` prefix to distinguish the procedure from non-test procedures in
+the same module.
+
+```
+    @assertEqual(4, 2 + 2)
+```
+
+This is the basic pFUnit testing directive that checks for equality between its two
+arguments. If they don't compare equal, pFUnit will flag the test as having failed and
+report it at the end of the run. Other asserts include `@assertTrue`, `@assertFalse`,
+and `@assertSameShape`.
+
+Importantly, pFUnit will stop running _this particular_ test if an `assertEqual` fails. If
+the arguments are arrays, pFUnit will report only the first index where they differ.
+
+The order of the arguments doesn't particularly matter, but when reporting errors pFUnit
+assumes the **first** argument is the _expected_ value, and the **second** argument is the
+_actual_ value.
+
+Something to be aware of here is that the pFUnit preprocessor doesn't like this directive
+split over multiple lines! Currently, we just have to live with long lines.
+
+Another thing to note is that all pFUnit directives (the keywords and functions beginning
+with `@`) are case insensitive: `@AssertEqual` is the same as `@assertEqual` and
+`@assertequal`.
+
+## Getting fancier
+
+### Setup and Teardown
+
+After writing a few tests, you may find that there's repeated code setting things up
+first, and then cleaning up afterwards. pFUnit allows you to declare subroutines to be run
+before and after each test in a module:
+
+```
+@before
+subroutine setup
+  ! Do something before every test
+end subroutine setup
+
+@after
+subroutine teardown
+  ! Do something after every test
+end subroutine teardown
+```
+
+The subroutine names are conventional, but `setup` and `teardown` are preferred.
+
+**Important!** If you mark one subroutine with either `@before` or `@after`, you **must**
+also have the corresponding one, even if it's just an empty routine.
+
+These `@before` and `@after` routines are run before/after each individual test, even if
+that test fails. This can be very useful to, for example, call the `<module>_finish`
+routine to cleanup a stella module, which helps make the tests more independent. Without the
+`@after` routine, a failure in one test might result in a stella module being in a bad or
+wrong state for the next test. To guard against other tests or modules not cleaning up
+after themselves correctly, you may wish to call the `<module>_finish` routine in both the
+setup and teardown routines. This helps ensure the tests are independent.
+
+### Tolerances
+
+By default, pFUnit compares values exactly. This is usually not what you want when dealing
+with floating point numbers. pFUnit can check equality within a tolerance, although
+unfortunately, as of v4.1.9, only absolute tolerances (`abs(actual-expected) <=
+tolerance`). Tolerances can be specified with the `tolerance` keyword to `@assertEqual`:
+
+```
+@assertEqual(3.14, pi, tolerance=1e-2)
+```
+
+### Message
+
+When a test contains multiple asserts, it can be tricky to tell exactly which assert
+caused a test to fail. Unfortunately, while pFUnit prints the values it's comparing, it
+doesn't print the _expressions_. Instead, it has a mechanism to give a bit more
+information with the `message` keyword:
+
+```
+@assertEqual(3.14, pi, message="comparing pi")
+```
+
+### MPI tests
+
+pFUnit has the ability to _parameterise_ a test over the number of MPI ranks. That is, it
+can rerun a test with different numbers of MPI processes. This can be useful to check that
+a function works with different ranks.
+
+Additionally, many routines often end up needing MPI to be set up because they contain
+some code like `if (proc0) then ...`. For these routines to work correctly when called
+from a pFUnit test, we essentially need to parameterise the test over one process.
+
+The form of an MPI test is a little different:
+
+```
+@test(npes=[1, 2])
+subroutine test_some_mpi(this)
+  class(MPITestMethod), intent(inout) :: this
+  ...
+```
+
+Here, we'll end up calling the test two times, first with one rank, and second with
+two. Next, our test subroutine now takes a single argument of `class(MPITestMethod)` --
+note it is `intent(inout)`. Conventionally we name it `this`, but the exact name is not
+important. This argument has some useful methods:
+
+```
+this%getMpiCommunicator()    ! Get the MPI_COMM for this test run
+this%getNumProcesses()       ! Wrapper for MPI_Comm_size
+this%getProcessRank()        ! Wrapper for MPI_Comm_rank
+```
+
+Parameterised tests, including MPI tests, **must** have setup/teardown routines. The setup
+routine **must** call `mp::init_mp`, but the teardown **must not** call `mp::finish_mp`:
+
+```
+@before
+subroutine setup(this)
+  use mp, only : init_mp
+  class (MpiTestMethod), intent(inout) :: this
+  ! Make sure stella variables like proc0 are populated correctly:
+  call init_mp(this%getMpiCommunicator())
+end subroutine setup
+
+@after
+subroutine teardown(this)
+  class (MpiTestMethod), intent(inout) :: this
+  ! No call to finish_mp!
+end subroutine teardown
+```
+
+Calling `finish_mp` will finalise MPI, which will cause problems for the next MPI test!
+
+### Parameterised tests
+
+It's possible to parameterise tests over other parameters than just MPI ranks, though it
+is a bit more involved and involves several pieces.
+
+Here's an example from one of the stella parameterised tests:
+
+```
+module test_antenna_data_mod
+  use PFUNIT_MOD
+
+  implicit none
+
+  @TestParameter
+  !> Type to hold parameter we want to scan in
+  type, extends(MpiTestParameter) :: test_antenna_parameter
+    integer :: nk_stir_in
+  contains
+    procedure :: toString
+  end type test_antenna_parameter
+
+  @TestCase(constructor = new_case)
+  !> Test fixture
+  type, extends(MpiTestCase) :: test_antenna_case
+    integer :: nk_stir_in
+  contains
+    procedure :: tearDown
+  end type test_antenna_case
+
+contains
+
+  !> Construct test_antenna_case from test_antenna_parameter
+  function new_case(test_parameter) result (test_case)
+    type(test_antenna_case) :: test_case
+    type(test_antenna_parameter), intent(in) :: test_parameter
+    test_case%nk_stir_in = test_parameter%nk_stir_in
+  end function new_case
+
+  !> Construct test_antenna_parameter
+  function new_parameter(nk_stir_in)
+    type(test_antenna_parameter) :: new_parameter
+    integer, intent(in) :: nk_stir_in
+    new_parameter%nk_stir_in = nk_stir_in
+  end function new_parameter
+
+  !> Serialise test_antenna_parameter as a string
+  function toString(this) result(string)
+    class(test_antenna_parameter), intent(in) :: this
+    character(:), allocatable :: string
+    allocate(character(len=10)::string)
+    write(string, '("nk_stir=", i2)') this%nk_stir_in
+  end function toString
+
+  !> Tear down test module
+  subroutine tearDown(this)
+    use antenna_data, only : finish_antenna_data
+    class(test_antenna_case), intent(inout) :: this
+    call finish_antenna_data
+  end subroutine tearDown
+
+  !> Define the parameters scan
+  function get_parameters() result(params)
+    type(test_antenna_parameter), allocatable :: params(:)
+
+    params = [ &
+         & new_parameter(nk_stir_in=-1), &
+         & new_parameter(nk_stir_in=3) &
+         & ]
+
+  end function get_parameters
+
+  @test(npes=[1,2,4], testParameters={get_parameters()})
+  !> Test for initialization with no antenna
+  subroutine test_init_antenna_data(this)
+    use antenna_data
+    implicit none
+    class (test_antenna_case), intent(inout) :: this
+
+    associate( nk_stir_in => this%nk_stir_in )
+      call init_antenna_data(nk_stir_in)
+
+      if (nk_stir_in < 0) then
+        ! Antenna off
+        @AssertFalse(ant_on)
+      else
+        ! Antenna on
+        @AssertTrue(ant_on)
+        @AssertEqual(nk_stir_in, nk_stir)
+      end if
+      @AssertSameShape(shape(nk_stir_in), shape(a_ant))
+      @AssertSameShape(shape(nk_stir_in), shape(b_ant))
+    end associate
+  end subroutine test_init_antenna_data
+
+end module test_antenna_data_mod
+```
+
+The parameterisation machinery looks very complicated here because we're just
+parameterising over a single integer, with the result that we end up defining two very
+similar types, but they are for different purposes, mostly to do with the internals of
+pFUnit and how Fortran works.
+
+Let's start with the test itself:
+
+```
+  @test(npes=[1,2,4], testParameters={get_parameters()})
+  !> Test for initialization with no antenna
+  subroutine test_init_antenna_data(this)
+    use antenna_data
+    implicit none
+    class (test_antenna_case), intent(inout) :: this
+```
+
+Our `@test` directive now has parameterisation over both MPI ranks and an extra set of
+parameters. The `testParameters` argument calls the function `get_parameters` to get an
+array of _parameters_ which are used to construct _test cases_. The test cases are passed
+into the test routine. pFUnit constructs the Cartesian product of `npes` and
+`testParameters`, that is, it calls the test routine with every combination of `npes` and
+`testParameters`.
+
+**Note**: the curly brackets `{...}` around the argument to `testParameters` are required.
+
+The function `get_parameters` looks like:
+
+```
+  function get_parameters() result(params)
+    type(test_antenna_parameter), allocatable :: params(:)
+
+    params = [ &
+         & new_parameter(nk_stir_in=-1), &
+         & new_parameter(nk_stir_in=3) &
+         & ]
+
+  end function get_parameters
+```
+
+This returns an `allocatable` array of `test_antenna_parameter` values. We want to scan
+over the `integer` `nk_stir_in` -- why can't we just return an `integer` array? This is
+because pFUnit needs to store the return value and has to know what type we're
+using. Because Fortran doesn't have generic data types, we're forced to use a derived type
+that extends pFUnit's `AbstractTestParameter`. Our definition of `test_antenna_parameter`:
+
+```
+  @TestParameter
+  type, extends(MpiTestParameter) :: test_antenna_parameter
+    integer :: nk_stir_in
+  contains
+    procedure :: toString
+  end type test_antenna_parameter
+```
+
+actually extends `MpiTestParameter`, which itself extends `AbstractTestParameter`. We use
+the `@TestParameter` directive to tell pFUnit this is our test parameter type. Notice
+that we also define a type-bound procedure or method called `toString`. This is used to
+print error messages. For our example, it can be quite simple:
+
+```
+  function toString(this) result(string)
+    class(test_antenna_parameter), intent(in) :: this
+    character(:), allocatable :: string
+    allocate(character(len=10)::string)
+    write(string, '("nk_stir=", i2)') this%nk_stir_in
+  end function toString
+```
+
+The `MpiTestParameter` base class takes care of writing the number of processes, so we
+just need to write the rest of the type to an `allocatable` `character`.
+
+We also need to write a function to construct a `test_antenna_parameter` from an
+`integer`:
+
+```
+  function new_parameter(nk_stir_in)
+    type(test_antenna_parameter) :: new_parameter
+    integer, intent(in) :: nk_stir_in
+    new_parameter%nk_stir_in = nk_stir_in
+  end function new_parameter
+```
+
+This isn't strictly necessary if you can make your array of test parameters some other
+way, but this is usually the easiest and least error prone method.
+
+Now that we have our test parameters, pFUnit uses these to construct a _test case_ which
+is finally passed to the test routine. Our test case type looks like this:
+
+```
+  @TestCase(constructor = new_case)
+  type, extends(MpiTestCase) :: test_antenna_case
+    integer :: nk_stir_in
+  contains
+    procedure :: tearDown
+  end type test_antenna_case
+```
+
+The `constructor` argument to the `@TestCase` directive tells pFUnit which function to use
+to make a new `test_antenna_case`. For us, this is very similar to the constructor for
+`test_antenna_parameter`:
+
+```
+  function new_case(test_parameter) result (test_case)
+    type(test_antenna_case) :: test_case
+    type(test_antenna_parameter), intent(in) :: test_parameter
+    test_case%nk_stir_in = test_parameter%nk_stir_in
+  end function new_case
+```
+
+We just copy the `nk_stir_in` member from the _parameter_ to the _case_.
+
+Also notice that the `test_antenna_case` type has a `tearDown` method. Unfortunately for
+parameterised tests, we can't just use the `@before` and `@after` directives. Instead, we
+need to overload the `setUp` and `tearDown` methods on the test case type. We don't have a
+`setUp` here, but we do have a `tearDown`, which just cleans up the module we're testing:
+
+```
+  subroutine tearDown(this)
+    use antenna_data, only : finish_antenna_data
+    class(test_antenna_case), intent(inout) :: this
+    call finish_antenna_data
+  end subroutine tearDown
+```
+
+Finally, now that we've constructed the parameters and the cases, we can actually use the
+case in the test routine itself:
+
+```
+  subroutine test_init_antenna_data(this)
+    use antenna_data
+    implicit none
+    class (test_antenna_case), intent(inout) :: this
+
+    associate( nk_stir_in => this%nk_stir_in )
+      call init_antenna_data(nk_stir_in)
+
+      if (nk_stir_in < 0) then
+        ! Antenna off
+        @AssertFalse(ant_on)
+      else
+        ! Antenna on
+        @AssertTrue(ant_on)
+        @AssertEqual(nk_stir_in, nk_stir)
+      end if
+      @AssertSameShape(shape(nk_stir_in), shape(a_ant))
+      @AssertSameShape(shape(nk_stir_in), shape(b_ant))
+    end associate
+  end subroutine test_init_antenna_data
+```
+
+We can access the `nk_stir_in` member of `test_antenna_case` through `this%nk_stir_in`. We
+actually use the Fortran `associate` block here to make a local name, `nk_stir_in`, to
+avoid writing `this%nk_stir_in` each time. The rest of the test looks like usual.
+
+[pfunit]: https://github.com/Goddard-Fortran-Ecosystem/pFUnit


### PR DESCRIPTION
Adds unit testing infrastructure -- no useful tests yet, just a demonstration. I'll talk to Bob about getting some real tests in.

Most of this has been adapted from GS2.

The various parts are:

- `externals/pFUnit`: git submodule, so that pFUnit is always available and doesn't need to be installed separately
- `scripts/build_pfunit`: helper script to build the pFUnit submodule, or to download and build a tarball if git isn't available
- `tests/unit/Makefile`: rules and targets for building pFUnit test suite
- `tests/unit/test_simple.pf`: simple test module just so there's something in place for the time being
- `tests/unit/testSuites.inc`: essentially a list of pFUnit tests
- `tests/unit/writing_tests.md`: some documentation on writing pFUnit tests