### PR TITLE
Add citation/copyright file, plus MIT licence

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,82 @@
+# This file is a citation metadata file in the Citation File Format
+# (http://citation-file-format.github.io/).
+#
+# It provides citation metadata for this version of stella
+
+cff-version: 1.1.0
+message: If you use stella in your work, please cite it using the following metadata.
+title: stella
+authors:
+  - family-names: Barnes
+    given-names: Michael
+    affiliation: University of Oxford
+    orcid: https://orcid.org/0000-0002-0177-1689
+
+  - family-names: St-Onge
+    given-names: Denis
+    affiliation: University of Oxford
+    orcid: https://orcid.org/0000-0003-3112-9221
+
+  - family-names: von Boetticher
+    given-names: Alexander
+    affiliation: University of Oxford
+
+  - family-names: Davies
+    given-names: Robert
+    affiliation: University of York
+
+  - family-names: García Regaña
+    given-names: José Manuel
+    affiliation: CIEMAT
+    orcid: https://orcid.org/0000-0001-7632-3357
+
+  - family-names: Dickinson
+    given-names: David
+    orcid: https://orcid.org/0000-0002-0868-211X
+    affiliation: University of York
+
+  - family-names: Dorland
+    given-names: William
+    orcid: https://orcid.org/0000-0003-2915-724X
+    affiliation: University of Maryland
+
+  - family-names: Hill
+    given-names: Peter Alec
+    orcid: https://orcid.org/0000-0003-3092-1858
+    affiliation: University of York
+
+  - family-names: Parker
+    given-names: Joseph Thomas
+    orcid: https://orcid.org/0000-0002-5573-6475
+    affiliation: United Kingdom Atomic Energy Authority
+
+  - family-names: Roach
+    given-names: Colin Malcolm
+    affiliation: Culham Centre for Fusion Energy
+
+  - family-names: Landreman
+    given-names: Matt
+    orcid: https://orcid.org/0000-0002-7233-577X
+
+  - family-names: Thienpondt
+    given-names: Hanne
+
+  - family-names: Numata
+    given-names: Ryusuke
+
+  - family-names: Parisi
+    given-names: Jason
+    affiliation: University of Oxford
+    orcid: https://orcid.org/0000-0003-1328-7154
+
+  - family-names: Hardman
+    given-names: Michael
+
+  - family-names: Kotschenreuther
+    given-names: Michael T.
+    affiliation: Institute for Fusion Studies, University of Texas
+
+  - family-names: Tatsuno
+    given-names: Tomo
+
+repository-code: https://github.com/stellaGK/stella

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,20 @@
+For a full list of authors please see CITATION.cff.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Resolves #3 

@mabarnes @DenSto I've been a bit presumptive and assumed you're alright with the MIT licence.

CITATION.cff is in the [Citation File Format](https://citation-file-format.github.io), and basically is a way of letting people cite the _software_. It can also reference e.g. the stella paper.

I've included GS2 authors from before 2018 with `git log --reverse --pretty=tformat:'%an' --date=short --before 2018 | sort | uniq`. @mabarnes Let me know if that should be different.