### PR TITLE
Minor change to build_pfunit to take value from environment

### DIFF
--- a/scripts/build_pfunit
+++ b/scripts/build_pfunit
@@ -15,7 +15,8 @@ pfunit_use_mpi="YES"
 
 # Which major version of pfunit are we using
 # Version 4+ needs very recent compilers
-pfunit_version_major=4
+# Defaults to version 4 is PFUNIT_VERSION_MAJOR is not set.
+pfunit_version_major=${PFUNIT_VERSION_MAJOR:-4}
 
 # Number of make jobs to use (i.e. argument to `make -j N`)
 make_jobs=1


### PR DESCRIPTION
Ensures that if `PFUNIT_VERSION_MAJOR` is set in the environment then this is the default pfunit version to try building.

This makes it slightly easier to control the version used when calling `build_pfunit` via make and if users have already set `PFUNIT_VERSION_MAJOR` for other codes.