### PR TITLE
Remove `theta0` dimension from netCDF output

### DIFF
--- a/stella_io.fpp
+++ b/stella_io.fpp
@@ -156,11 +156,6 @@ contains
       status = nf90_def_dim (ncid, 'tube', ntubes, ntubes_dim)
       if (status /= nf90_noerr) call netcdf_error (status, dim='tube')
     endif
-    status = nf90_inq_dimid(ncid,'theta0',nakx_dim)
-    if (status /= nf90_noerr) then
-      status = nf90_def_dim (ncid, 'theta0', nakx, nakx_dim)
-      if (status /= nf90_noerr) call netcdf_error (status, dim='theta0')
-    endif
     status = nf90_inq_dimid(ncid,'zed',nttot_dim)
     if (status /= nf90_noerr) then
       status = nf90_def_dim (ncid, 'zed', 2*nzgrid+1, nttot_dim)


### PR DESCRIPTION
`theta0` is created as both a dimension and variable in the netCDF file, but the variable has dimensions `(theta0, ky)`. This leads to the following error if the output file is read in with `xarray`:

> MissingDimensionsError: 'theta0' has more than 1-dimension and the same name as one of its dimensions ('theta0', 'ky'). xarray disallows such variables because they conflict with the coordinates used to label dimensions.

The cause of this is because when the `theta0` dimension is created in `stella_io.fpp` it reuses the `nakx_dim`, so the variables that have a `kx` dimension get a `theta0` dimension instead. This might be what is wanted, but I suspect not.

After this PR, in the output netCDF file, the `theta0` variable will have dimensions `(kx, ky)`, and the `kx` variable will have dimension `(kx)`.