### PR TITLE
Add integrated test framework

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,5 +33,8 @@ jobs:
           nf-config --all
       - uses: actions/checkout@v2
 
+      - name: Install integrated test dependencies
+        run: pip3 install --user -r tests/integrated/requirements.txt
+
       - name: Build stella
         run: ./scripts/ci_build_and_run.sh

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,142 @@ stella_save.f90
 externals/pFUnit_build
 unit_tests
 tests/unit/*.F90
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ include tests/unit/Makefile
 tests/integrated/Makefile:
 include tests/integrated/Makefile
 
-check: check-unit
+check: check-unit check-integrated
 
 ############################################################### SPECIAL RULES
 

--- a/Makefile
+++ b/Makefile
@@ -347,6 +347,9 @@ sinclude Makefile.target_$(GK_PROJECT)
 tests/unit/Makefile:
 include tests/unit/Makefile
 
+tests/integrated/Makefile:
+include tests/integrated/Makefile
+
 check: check-unit
 
 ############################################################### SPECIAL RULES

--- a/scripts/ci_build_and_run.sh
+++ b/scripts/ci_build_and_run.sh
@@ -6,4 +6,4 @@ export GK_SYSTEM=gnu_ubuntu
 make -I Makefiles -j2
 
 make -I Makefiles build-pfunit-library
-make -I Makefiles check-unit
+make -I Makefiles check

--- a/tests/integrated/Makefile
+++ b/tests/integrated/Makefile
@@ -1,0 +1,22 @@
+# See README.md for more information on these integrated tests
+
+# This directory
+integrated_test_dir = $(GK_HEAD_DIR)/tests/integrated
+
+# Create a virtualenv and install the test dependencies there
+create-test-virtualenv:
+	bash -c "cd $(integrated_test_dir); \
+		python3 -m venv venv; \
+		source venv/bin/activate; \
+		pip install -r requirements.txt; \
+		deactivate; \
+	"
+
+# Run the integrated tests
+check-integrated: check-integrated-dependencies stella
+	@echo "Running: integrated tests"
+	@pytest
+
+# Check that all the Python dependencies are importable
+check-integrated-dependencies:
+	@python3 $(integrated_test_dir)/check_integrated_requirements.py

--- a/tests/integrated/README.md
+++ b/tests/integrated/README.md
@@ -1,0 +1,105 @@
+Integrated tests
+================
+
+The integrated tests here are written using the Python [pytest][pytest] package,
+and make use of [xarray][xarray] for reading in the data. To install these
+packages in a standalone environment, you can run:
+
+    make create-test-virtualenv
+    source tests/integrated/venv/bin/activate
+
+This will create a Python [virtual environment][venv] with the packages needed
+for running the tests. You can then run all the tests:
+
+    make check-integrated-tests
+
+This assumes that the executable is located two directories above this one. You
+can set the environment variable `STELLA_EXE_PATH` to the location of the
+`stella` executable if it has been built somewhere else.
+
+Writing new tests
+-----------------
+
+The testing framework is setup to automatically find files called `test_*.py`
+and run any functions it finds in them called `test_*`. Writing a new integrated
+test for `stella` is as "simple" as writing a new function that starts with
+`test_`.
+
+Let's look at a basic test, `test_simple_run` in
+[`simple/test_simple.py`](simple/test_simple.py) to see how to write a test that
+runs `stella` and checks the output netCDF file:
+
+```python
+def test_simple_run(tmp_path):
+    """Run a short test case to check that the output is generated with
+    the expected fields, and the expected number of timesteps
+
+    """
+```
+
+The function takes one argument called `tmp_path`: this is a path to a temporary
+directory done magically by the test framework `pytest`. This is used so we can run
+the test in an isolated environment, and not worry about other tests potentially
+interfering with output files, for example.
+
+We can help out future developers by providing a brief description of the aim of
+the test, how it works, and so on, in the docstring.
+
+The first three lines:
+
+```python
+    input_filename = "simple.in"
+    copy_input_file(input_filename, tmp_path)
+    os.chdir(tmp_path)
+```
+
+do some setting up by copying the input file we're using to the temporary
+directory `pytest` has created for us, and then changing the working directory
+to there. `copy_input_file` is a helper function defined in the same file.
+
+Next we run `stella` with our input file using another helper function
+`run_stella`:
+
+```python
+    run_stella(get_stella_path(), input_filename)
+```
+
+`run_stella` also checks that `stella` completed successfully. `get_stella_path`
+is yet another helper function that returns the absolute path to the `stella`
+executable.
+
+We can now read the output file using `xarray`:
+
+```python
+    with xr.open_dataset(tmp_path / input_filename.replace("in", "out.nc")) as df:
+```
+
+`xarray` gives us a nice dictionary-style interface to the netCDF file, and has
+some nice features like lazy loading -- only loading the datasets we actually
+use, when we use them. Using the `with` statement like this just ensures that
+the file gets closed properly should something unexpected happen in the rest of
+the test. This can be important as netCDF files can be fussy about being closed.
+
+The remainder of this function does the actual testing:
+
+```python
+        expected_keys = [
+            "phi2",
+            "phi_vs_t",
+        ]
+
+        for field in expected_keys:
+            assert field in df
+
+        assert len(df["t"]) == 11
+        assert np.allclose(df["t"][-1], 10.0)
+```
+
+We use `assert` statements to check properties of the output file. In this test,
+we check that the output file contains some expected diagnostics, that the
+length of the time dimension is correct, and that the last timestep matches what
+we expect.
+
+[pytest]: https://pytest.org
+[xarray]: http://xarray.pydata.org
+[venv]: https://docs.python.org/3/library/venv.html

--- a/tests/integrated/check_integrated_requirements.py
+++ b/tests/integrated/check_integrated_requirements.py
@@ -1,0 +1,40 @@
+# This script just checks if we can import all the modules listed in
+# requirements.txt
+
+import importlib
+import pathlib
+import textwrap
+
+requirements_file = pathlib.Path(__file__).parent / "requirements.txt"
+
+with open(requirements_file, "r") as f:
+    contents = f.readlines()
+
+requirements = []
+for line in contents:
+    if line.startswith("#"):
+        continue
+    module = line.split("=")[0]
+    requirements.append(module.replace(">", "").replace("~", ""))
+
+failed_modules = []
+for requirement in requirements:
+    try:
+        importlib.import_module(requirement)
+    except ImportError:
+        failed_modules.append(requirement)
+
+if failed_modules:
+    list_of_failed_modules = ", ".join(failed_modules)
+    print(
+        textwrap.dedent(
+            f"""\
+            Could not import: {list_of_failed_modules}
+            Run:
+                make create-test-virtualenv
+                source tests/integrated/venv/bin/activate
+            to install and activate test dependencies
+            """
+        )
+    )
+    exit(1)

--- a/tests/integrated/requirements.txt
+++ b/tests/integrated/requirements.txt
@@ -1,0 +1,5 @@
+# These modules are required for the stella integrated tests
+netCDF4>=1.4.0
+numpy>=1.17
+pytest~=6.2
+xarray~=0.18

--- a/tests/integrated/simple/simple.in
+++ b/tests/integrated/simple/simple.in
@@ -1,0 +1,143 @@
+! JET shot 92174
+
+&zgrid_parameters
+ nzed = 32
+ nperiod = 1
+ boundary_option="linked"
+/
+
+&geo_knobs
+ geo_option = 'miller'
+/
+
+&millergeo_parameters
+ nzed_local = 128
+ rhoc = 9.7427e-01 ! r/a
+ shat = 3.3594e+00
+ qinp = 5.0848e+00
+ rmaj = 3.1340e+00
+ rgeo = 3.1191e+00
+ shift = -3.4508e-01
+ kappa = 1.5504e+00
+ kapprim = 9.4963e-01
+ tri = 2.6253e-01
+ triprim = 7.3680e-01
+ betaprim = 0.58e-01
+
+ d2qdr2 = 0.0
+ d2psidr2 = 0.0
+ betadbprim = 0.0
+/
+
+&physics_flags
+ full_flux_surface = .false.
+ nonlinear = .true.
+/
+
+&parameters
+ zeff = 1.0
+ beta = 0.01
+ vnew_ref = 0.01
+ rhostar = 0.01
+/
+
+&vpamu_grids_parameters
+ nvgrid = 3 ! 64
+ nmu = 2 !32
+ vpa_max = 3.0
+/
+
+&time_advance_knobs
+ explicit_option="rk2"
+/
+
+&kt_grids_knobs
+ grid_option='box'
+/
+
+&kt_grids_box_parameters
+ ny = 2
+ nx = 2
+ y0 = 20.0
+ jtwist = 5
+/
+
+&init_g_knobs
+ chop_side = F
+ phiinit=   1.0e-2
+ restart_file = "nc/example.nc"
+ ginit_option= "noise"
+ width0 = 1.0
+/
+
+&knobs
+ fphi =   1.0
+ fapar =  0.0
+ fbpar = 0.0
+ zed_upwind = 0.02
+ time_upwind = 0.02
+ vpa_upwind = 0.02
+ delt = 0.02
+ nstep = 500
+ mat_gen = .false.
+/
+
+&species_knobs
+ nspec= 2
+ species_option = 'stella'
+/
+
+&species_parameters_1
+ z=   1.0
+ mass=   2.0
+ dens=   1.0
+ temp=   1.0
+ tprim = 11.150280766906535 ! by minor radius, multiply by 3.2 to get R/L_T
+ fprim = 10.076043143968478
+ type='ion'
+/
+
+&species_parameters_2
+ z=   -1.0
+ mass=   0.00054
+ dens=   1.0
+ temp=   0.5570183368724737
+ tprim=  42.296287675811435
+ fprim=  10.076043143968478
+ type='electron'
+/
+
+&stella_diagnostics_knobs
+ nwrite = 50
+ nsave = 1000
+ save_for_restart = .false.
+ write_omega = .false.
+ write_phi_vs_time = .true.
+ write_gvmus = .false.
+ write_gzvs = .false.
+/
+
+&reinit_knobs
+ delt_adj = 2.0
+ delt_minimum = 1.e-4
+/
+
+&layouts_knobs
+ xyzs_layout = 'yxzs'
+ vms_layout = 'vms'
+/
+
+&neoclassical_input
+ include_neoclassical_terms = .false.
+ neo_option = 'sfincs'
+/
+
+&sfincs_input
+ nproc_sfincs = 2
+ nxi = 16
+ nx = 5
+/
+
+&dissipation
+ hyper_dissipation = .true.
+/

--- a/tests/integrated/simple/test_simple.py
+++ b/tests/integrated/simple/test_simple.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import os
+import pathlib
+import shutil
+import subprocess
+import xarray as xr
+
+
+def get_test_directory() -> pathlib.Path:
+    """Get the directory of this test file"""
+    return pathlib.Path(__file__).parent
+
+
+def get_stella_path() -> pathlib.Path:
+    """Returns the absolute path to the stella executable
+
+    Can be controlled by setting the STELLA_EXE_PATH environment variable
+    """
+    default_path = get_test_directory() / "../../../stella"
+    stella_path = pathlib.Path(os.environ.get("STELLA_EXE_PATH", default_path))
+    return stella_path.absolute()
+
+
+def run_stella(stella_path: str, input_filename: str) -> int:
+    """Run stella with a given input file"""
+    subprocess.run([stella_path, input_filename]).check_returncode()
+
+
+def copy_input_file(input_filename: str, destination):
+    """Copy input_filename to destination directory"""
+    shutil.copyfile(get_test_directory() / input_filename, destination / input_filename)
+
+
+def test_simple_run(tmp_path):
+    """Run a short test case to check that the output is generated with
+    the expected fields, and the expected number of timesteps
+
+    """
+
+    input_filename = "simple.in"
+    copy_input_file(input_filename, tmp_path)
+    os.chdir(tmp_path)
+    run_stella(get_stella_path(), input_filename)
+
+    with xr.open_dataset(tmp_path / input_filename.replace("in", "out.nc")) as df:
+        expected_keys = [
+            "phi2",
+            "phi_vs_t",
+        ]
+
+        for field in expected_keys:
+            assert field in df
+
+        assert len(df["t"]) == 11
+        assert np.allclose(df["t"][-1], 10.0)


### PR DESCRIPTION
This PR adds a framework for running integrated/system tests -- that is, running a whole `stella` simulation and verifying the outputs in same manner.

I've used Python to write this because a) it's generally installed everywhere, including on HPC systems, and b) the `pytest` framework does a lot of the heavy lifting in terms of finding and running the tests. I've also used `xarray` to read in the output files -- the plasma community is slowly converging on this as the de facto standard (see Tom Nicholas' excellent blogpost: https://hackmd.io/@TomNicholas/rkyERwcoO)

This does mean that in order to run the integrated tests you will need a few Python packages:
- pytest
- xarray
- netCDF4
- numpy

I've added the `make create-test-virtualenv` target to simplify installing these. If you don't have them installed and try to run the tests with either `make check` (both unit and integrated tests) or `make check-integrated`, you should get a nice error message like:

```
$ make check-integrated
Could not import: netCDF4, numpy, pytest, xarray
Run:
    make create-test-virtualenv
    source tests/integrated/venv/bin/activate
to install and activate test dependencies

make: *** [tests/integrated/Makefile:22: check-integrated-dependencies] Error 1
```

`tests/integrated/README.md` describes how to write a test.

The one test I've added so far is really just to check that `stella` runs and does _something_. It would be good to add some tests like the cyclone base case, or stellarator equivalent. Is there also a Rosenbluth-Hinton equivalent?

It would be good to get some feedback about how this fares on people's local machines.