### PR TITLE
Minor fixes for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,8 +165,8 @@ sinclude Makefile.local
 export F90FLAGS
 export NETCDF_INC
 export NETCDF_LIB
-export UTILS=utils
-export GEO=geo
+export UTILS=$(GK_HEAD_DIR)/utils
+export GEO=$(GK_HEAD_DIR)/geo
 export VMEC=$(GEO)/vmec_interface
 export LIBSTELL=$(VMEC)/mini_libstell
 LIBSTELL_LIB=$(LIBSTELL)/mini_libstell.a
@@ -288,7 +288,7 @@ ifneq ($(TOPDIR),$(CURDIR))
 	SUBDIR=true
 endif
 
-VPATH = $(UTILS):$(GEO):../$(UTILS):../$(GEO):$(VMEC)
+VPATH = $(UTILS):$(GEO):$(VMEC)
 # this just removes non-existing directory from VPATH
 VPATH_tmp := $(foreach tmpvp,$(subst :, ,$(VPATH)),$(shell [ -d $(tmpvp) ] && echo $(tmpvp)))
 VPATH = .:$(shell echo $(VPATH_tmp) | sed "s/ /:/g")
@@ -300,7 +300,7 @@ DEPEND=Makefile.depend
 DEPEND_CMD=$(PERL) fortdep
 
 # most common include and library directories
-DEFAULT_INC_LIST = . $(UTILS) $(LIBSTELL) $(VMEC) $(GEO) .. ../$(UTILS) ../$(GEO)
+DEFAULT_INC_LIST = . $(UTILS) $(LIBSTELL) $(VMEC) $(GEO)
 DEFAULT_LIB_LIST =
 DEFAULT_INC=$(foreach tmpinc,$(DEFAULT_INC_LIST),$(shell [ -d $(tmpinc) ] && echo -I$(tmpinc)))
 DEFAULT_LIB=$(foreach tmplib,$(DEFAULT_LIB_LIST),$(shell [ -d $(tmplib) ] && echo -L$(tmplib)))

--- a/Makefile.target_stella
+++ b/Makefile.target_stella
@@ -39,3 +39,5 @@ geo.a:  $(GEO_OBJ)
 
 distclean:
 	-rm -f stella stella.x
+
+vmec_to_stella_geometry_interface.o: vmec


### PR DESCRIPTION
Fixes a couple of issues I run into occasionally:

- `VPATH` can include paths outside of the `stella` project
- `make -j` can error if it tries to build `vmec_to_stella_geometry_interface` before `mini_libstell.a`