### PR TITLE
Automatically build documentation/website

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Documenation
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0
+
+    - name: Install dependencies
+      run: sudo apt update &&
+           sudo apt install -y
+                 make
+                 libfftw3-dev
+                 libnetcdf-dev
+                 libnetcdff-dev
+                 python3
+                 python3-pip
+                 rsync
+
+    - name: Install FORD
+      run: |
+        pip3 install --upgrade pip
+        pip3 install ford
+        ford --version
+    - name: Build documentation
+      run: |
+        export GK_SYSTEM=gnu_ubuntu
+        make -I Makefiles doc
+    - name: Checkout pages branch
+      run: |
+        git checkout -b gh-pages --track origin/gh-pages
+    - name: Move built documentation
+      run: |
+        cp -vr docs/html/* .
+        rm -rf docs/html
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Add built documentation
+        add_options: '--all'

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ stella_save.f90
 externals/pFUnit_build
 unit_tests
 tests/unit/*.F90
+docs/html/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -446,8 +446,10 @@ check_ford_install:
 	@echo "Ford command $(FORD) not in path -- is it installed?\\n\\tConsider installing with 'pip install --user ford' and add ${HOME}/.local/bin to PATH" ; which $(FORD)
 endif
 
+GIT_VERSION := $(shell git describe --tags --long --match "v*" --first-parent HEAD)
+
 doc: docs/stella_docs.md check_ford_install
-	$(FORD) $(INC_FLAGS) $<
+	$(FORD) $(INC_FLAGS) -r $(GIT_VERSION) $<
 
 cleandoc:
 	@echo "FORD docs"

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ ARCHFLAGS 	= cr
 RANLIB		= ranlib
 AWK 		= awk
 PERL		= perl
+FORD       ?= ford
 
 MPI_INC	?=
 MPI_LIB ?=
@@ -434,3 +435,20 @@ revision:
 
 TAGS:	*.f90 *.fpp */*.f90 */*.fpp
 	etags $^
+
+############################################################# Documentation
+
+ifneq ("$(wildcard $(shell which $(FORD) 2>/dev/null))","")
+check_ford_install:
+	@echo "Using ford at $(shell which $(FORD))"
+else
+check_ford_install:
+	@echo "Ford command $(FORD) not in path -- is it installed?\\n\\tConsider installing with 'pip install --user ford' and add ${HOME}/.local/bin to PATH" ; which $(FORD)
+endif
+
+doc: docs/stella_docs.md check_ford_install
+	$(FORD) $(INC_FLAGS) $<
+
+cleandoc:
+	@echo "FORD docs"
+	-rm -rf docs/html

--- a/README.md
+++ b/README.md
@@ -1,10 +1,44 @@
 # stella
 
-INSTALLATION
-1) set GK_SYSTEM='system', with system replaced by the appropriate system on which you are running.
-2) make sure that fftw3 and netcdf libraries are installed.
-3) set the environmental variables FFTW_LIB_DIR (directory containing libfftw3.a),
-FFTW_INC_DIR (directory including fftw3.f), NETCDF_LIB_DIR (directory containing libnetcdff.a),
-and NETCDF_INC_DIR (directory including netcdf.inc)
-4) set the environmental variable MAKEFLAGS=-IMakefiles
-5) type 'make'
+![Github Actions badge](https://github.com/stellaGK/stella/actions/workflows/tests.yml/badge.svg)
+
+stella solves the gyrokinetic-Poisson system of equations in the local limit
+using an operator-split, implicit-explicit numerical scheme. It is capable of
+evolving electrostatic fluctuations with fully kinetic electrons and an
+arbitrary number of ion species in general magnetic geometry, including
+stellarators.
+
+## Dependencies
+
+stella has several optional dependencies:
+
+- MPI
+- netCDF Fortran
+- FFTW3
+
+## Installation
+
+1. Set `GK_SYSTEM='system'`, with `system` replaced by the appropriate system on
+   which you are running. See the `Makefiles` directory for a list of supported
+   systems.
+2. Optionally, set the following environment variables to override the locations
+   in the `GK_SYSTEM` Makefile:
+   - `FFTW_LIB_DIR`: directory containing libfftw3
+   - `FFTW_INC_DIR`: directory including fftw3.f
+   - `NETCDF_LIB_DIR`: directory containing libnetcdff
+   - `NETCDF_INC_DIR`: directory including netcdf.inc
+4. Set the environment variable `MAKEFLAGS=-IMakefiles`, or set `-IMakefiles`
+   when you run `make`
+5. Run `make`
+
+For example, to compile on Ubuntu:
+
+```bash
+# using bash:
+export GK_SYSTEM=gnu_ubuntu
+export MAKEFLAGS=-IMakefiles
+make
+
+# or in one line:
+make -IMakefiles GK_SYSTEM=gnu_ubuntu
+```

--- a/docs/page/writing_documentation.md
+++ b/docs/page/writing_documentation.md
@@ -1,0 +1,251 @@
+---
+title: Writing Documentation
+---
+
+[TOC]
+
+stella uses [FORD][ford] to automatically build this online documentation. There are two
+sorts of documentation that get built: in-source and out-of-source. This page describes
+how to write both sorts. The website will get built automatically when your changes are
+merged into `master`.
+
+# In-source documentation
+
+Special Fortran comments of the form `!>` are used to document procedures, variables and
+programs using [FORD][ford]. These comments are sometimes called "docstrings". FORD can
+understand these comments before, after or in-line with the thing to be documented, but
+the preferred style in stella is to put the comment before the entity, like in this example:
+
+``` fortran
+!> This is module-level documentation, describing the overall purpose of this module.
+!> Documentation comments can be over several lines.
+module my_module
+    implicit none
+
+    !> Docstrings can go on derived types
+    type :: my_type
+        !> Docstrings can include in-line LaTeX like this: \(R\)
+        real :: R_major
+        !> Or as a displayed equation:
+        !>   $$\frac{\partial R}{\partial \psi}$$
+        real :: R_major_prime
+        !> Code-formatting uses `backticks`
+        integer :: n_R
+    end type my_type
+
+contains
+
+    !> We can document functions/subroutines
+    real function gradient(R, psi)
+        !> In order to separate the docstring for each argument...
+        real, intent(in) :: R
+        !> ...it's best to have each argument on its own line
+        real, intent(in) :: psi
+    end function gradient
+
+end module my_module
+```
+
+The [FORD wiki][ford_wiki] has more documentation on how to write these docstrings. Please
+note that while FORD accepts `!<` comments _after_ or in-line with the thing to be
+documented, the stella style is to stick to `!>` _before_ and on a separate line.
+
+# Out-of-source documentation
+
+As well as the code documentation, we also have some extra documentation. The source for
+these pages in still kept in the stella git repository, and are built into the website at the
+same time. These extra pages are written in [Markdown][markdown-guide], with some
+extensions (see [the Python markdown implementation][python-markdown]). There's a short
+[cheat sheet](#cheat-sheet) at the bottom of this page.
+
+## Add a new page
+
+All the out-of-source documentation is under `docs/pages`. FORD converts the directory
+hierarchy in to a hierarchy of HTML pages. To add a new page, simply create a new file
+under `docs/pages`, and use the file extension `.md`. **Your file must contain the
+following at the very top**:
+
+``` markdown
+---
+title: Page title
+---
+```
+
+Without this metadata section, FORD will not parse the file as part of the documentation.
+
+In this metadata section, you can also have `author` and `date` items.
+
+Another useful feature, is put `[TOC]` on its own line after the metadata section. This
+produces a hyperlinked table of contents.
+
+See the [FORD wiki][ford_pages] for a more detailed description.
+
+## Converting LaTeX to Markdown
+
+The easiest way to convert LaTeX to Markdown is to use [Pandoc][pandoc]. This nifty tool
+understands tons of text formats and can convert between them easily, and will get the
+vast majority of the heavy lifting done for you. Due to the complexities of LaTeX and the
+simplicity of Markdown, it may require some manual tidying up after the initial
+conversion.
+
+To get started, run Pandoc:
+
+``` shell
+$ pandoc --standalone --from=latex --to=gfm my_docs.tex --output docs/pages/my_docs.md
+```
+
+FORD is a bit fussier about the metadata section at the top, compared to what Pandoc
+produces, so you may need to manually adjust it.
+
+Acceptable:
+
+``` markdown
+---
+title: On the Electrodynamics of Moving Bodies
+author: A. Einstein
+---
+```
+
+Unacceptable:
+
+``` markdown
+---
+title: Does the Inertia of a Body Depend upon its Energy Content?
+author: 
+- 'A. Einstein'
+---
+```
+
+which is a possible output from Pandoc.
+
+FORD can render LaTeX included in the markdown, with just a couple of gotchas. The most
+important one is that in-line maths **must** use `\(...\)` rather than `$...$`. Displayed
+equations can be written between `$$...$$`, but note that this does not number the
+resulting equation.
+
+Normal `\begin{equation} ... \end{equation}` environments can be used to get numbered
+equations, along with `\label{eq:something}` and `\eqref{eq:something}` to refer to them.
+
+This example:
+
+```
+To obtain the distribution function at the next time step, \(g^{n+1}\), we could combine
+these equations
+
+$$A g^{n+1} + B g^{n} = DF^{-1}Gg^{n+1} + E\phi^{n},$$
+```
+
+is rendered as:
+
+> To obtain the distribution function at the next time step, \(g^{n+1}\), we could combine
+> these equations
+>
+> $$A g^{n+1} + B g^{n} = DF^{-1}Gg^{n+1} + E\phi^{n},$$
+
+while
+
+```
+\begin{equation}
+F \phi^{n+1} = G g^{n+1}
+\label{eq:QN}
+\end{equation}
+
+\eqref{eq:QN} is the quasi-neutrality equation
+```
+
+is rendered as
+
+> \begin{equation}
+> F \phi^{n+1} = G g^{n+1}
+> \label{eq:QN}
+> \end{equation}
+> 
+> \eqref{eq:QN} is the quasi-neutrality equation
+
+
+## Linking to sections
+
+Section titles within a page get converted into HTML "anchors" which can be linked to. The
+section names are first converted to lowercase and spaces replaced with hyphens. To link
+to a section, use the usual link syntax and add `#` in front of the converted section
+name.
+
+This:
+
+``` markdown
+Link to [this section](#linking-to-sections)
+```
+
+becomes:
+
+> Link to [this section](#linking-to-sections)
+
+## Linking to source documentation
+
+Linking directly to the code documentation is possible using FORD's syntax, which is
+described
+[here](https://github.com/Fortran-FOSS-Programmers/ford/wiki/Writing-Documentation#links):
+
+This:
+
+``` markdown
+The two linear steps \(L\) are performed by the function [[dist_fn:invert_rhs]] in [[dist_fn.fpp(file)]]
+```
+
+is rendered as:
+
+> The two linear steps \(L\) are performed by the function [[dist_fn:invert_rhs]] in [[dist_fn.fpp(file)]]
+
+## Building the documentation locally
+
+[FORD][ford] can be easily installed with `pip`:
+
+``` shell
+$ pip3 install --user ford
+```
+
+After installing FORD, simply run `make doc`. This will build the documentation under
+`docs/html`:
+
+``` shell
+$ make doc
+```
+
+Then open `docs/html/index.html` in your favourite browser.
+
+## Cheat sheet
+
+[See here][markdown-guide] for a comprehensive guide to Markdown.
+
+Here's a quick little cheat sheet:
+
+| Syntax          | Description                |
+|-----------------|----------------------------|
+| Heading         | `# Top-level`              |
+|                 | `## Section`               |
+|                 | `### Sub-section`          |
+| Bold            | `**bold text**`            |
+| Italic          | `*italicised text*`        |
+| Code            | `` `code` ``               |
+| Blockquote      | `> Block quote`            |
+| Ordered lists   | `1. First item`            |
+|                 | `2. Second item`           |
+|                 | `3. Third item`            |
+| Unordered lists | `- First item`             |
+|                 | `- Second item`            |
+|                 | `- Third item`             |
+| Link            | `[title](www.example.com)` |
+| Image           | `![alt text](image.jpg)`   |
+
+
+[ford]: https://github.com/Fortran-FOSS-Programmers/ford
+[ford_wiki]: https://github.com/Fortran-FOSS-Programmers/ford/wiki
+[ford_pages]: https://github.com/Fortran-FOSS-Programmers/ford/wiki/Writing-Pages
+[markdown-guide]: https://www.markdownguide.org
+[pandoc]: https://pandoc.org/
+[python-markdown]: https://python-markdown.github.io/
+
+<!-- Local Variables: -->
+<!-- mode: gfm -->
+<!-- fill-column: 90 -->
+<!-- End: -->

--- a/docs/stella_docs.md
+++ b/docs/stella_docs.md
@@ -1,0 +1,31 @@
+---
+project: stella
+project_github: https://github.com/stellaGK/stella/
+summary: stella is a flux tube gyrokinetic code for micro-stability and turbulence simulations of strongly magnetised plasma
+author: The stella team
+author_description:
+    stella has been developed by many developers
+    See the [citation
+    file](https://github.com/stellaGK/stella/blob/master/CITATION.cff)
+    for a complete list
+src_dir: ..
+exclude_dir: ../externals
+             ../tests
+             ./html
+output_dir: ./html
+predocmark: >
+docmark: <
+fpp_extensions: fpp
+                F90
+display: public
+         protected
+         private
+print_creation_date: true
+md_extensions: markdown.extensions.toc
+---
+
+stella solves the gyrokinetic-Poisson system of equations in the local limit
+using an operator-split, implicit-explicit numerical scheme. It is capable of
+evolving electrostatic fluctuations with fully kinetic electrons and an
+arbitrary number of ion species in general magnetic geometry, including
+stellarators.

--- a/stella.f90
+++ b/stella.f90
@@ -70,9 +70,10 @@ program stella
 
 contains
 
-  !==============================================
-  !============ INITIATE STELLA =================
-  !==============================================
+  !> Initialise stella
+  !>
+  !> Calls the initialisation routines for all the geometry, physics, and
+  !> diagnostic modules
   subroutine init_stella(istep0, VERNUM, VERDATE)
     use mp, only: init_mp, broadcast, sum_allreduce
     use mp, only: proc0,job, scope, subprocs, crossdomprocs
@@ -124,9 +125,12 @@ contains
 
     implicit none
 
+    !> Starting timestep: zero unless the simulation has been restarted
     integer, intent (out) :: istep0
-    character(len=4), intent (in) :: VERNUM 
-    character(len=10), intent (in) :: VERDATE 
+    !> stella version number
+    character(len=4), intent (in) :: VERNUM
+    !> Release date
+    character(len=10), intent (in) :: VERDATE
     logical :: exit, list, restarted, needs_transforms
     character (500), target :: cbuff
     integer, dimension (:), allocatable  :: seed
@@ -309,17 +313,17 @@ contains
 
   end subroutine init_stella
 
-  !==============================================
-  !============ WRITE START MESSAGE =============
-  !==============================================
+  !> Write the start message to screen
   subroutine write_start_message(VERNUM, VERDATE)
     use mp, only: proc0, nproc
 
     implicit none
 
+    !> stella version number
+    character(len=4), intent (in) :: VERNUM
+    !> Release date
+    character(len=10), intent (in) :: VERDATE
     character(len=23) :: str
-    character(len=4), intent (in) :: VERNUM 
-    character(len=10), intent (in) :: VERDATE 
 
     if (proc0) then
       write (*,*) ' '
@@ -361,9 +365,7 @@ contains
 
   end subroutine write_start_message
 
-  !==============================================
-  !=============== FINISH STELLA ================
-  !==============================================
+  !> Finish a simulation, call the finialisation routines of all modules
   subroutine finish_stella (last_call)
 
     use mp, only: finish_mp

--- a/stella_diagnostics.f90
+++ b/stella_diagnostics.f90
@@ -1,3 +1,4 @@
+!> Routines for calculating and writing various physical diagnostics
 module stella_diagnostics
 
   implicit none
@@ -23,27 +24,27 @@ module stella_diagnostics
   logical :: write_fluxes_kxkyz  
   logical :: flux_norm
 
-  ! Arrays needed for averaging in x,y,z
+  !> Arrays needed for averaging in x,y,z
   real, dimension (:), allocatable :: pflux_avg, vflux_avg, qflux_avg, heat_avg
   real, dimension (:,:,:), allocatable :: pflux, vflux, qflux, exchange
 
-  ! Needed for calculating growth rates and frequencies
+  !> Needed for calculating growth rates and frequencies
   complex, dimension (:,:,:), allocatable :: omega_vs_time
 
-  ! Initialized variables
+  !> Current maximum index of the time dimension in the netCDF file
   integer :: nout = 1
+  !> Has this module been initialised?
   logical :: diagnostics_initialized = .false.
 
-  ! Debugging
+  !> Debugging
   logical :: debug = .false.
 
 contains
 
-  !==============================================
-  !====== INITIATE STELLA DIAGNOSTICS ===========
-  !==============================================
-  ! Broadcast the parameters from the namelist "stella_diagnostics_knobs"
-  ! and open/append the netcdf file and the ascii files.
+  !> Initialise the [[stella_diagnostics]] module
+  !>
+  !> Broadcast the parameters from the namelist "stella_diagnostics_knobs"
+  !> and open/append the netcdf file and the ascii files.
   subroutine init_stella_diagnostics (restart, tstart)
 
     use zgrid, only: init_zgrid
@@ -58,7 +59,9 @@ contains
 
     implicit none
 
+    !> Has this simulation been restarted?
     logical, intent (in) :: restart
+    !> Current simulation time
     real, intent (in) :: tstart
 
     ! Only initialize the diagnostics once
@@ -110,9 +113,9 @@ contains
 
   end subroutine init_stella_diagnostics
   
-  !==============================================
-  !============== READ PARAMETERS ===============
-  !==============================================
+  !> Read the diagnostic input parameters from the input file
+  !>
+  !> Namelist: `stella_diagnostics_knobs`
   subroutine read_parameters
 
     use mp, only: proc0
@@ -154,9 +157,7 @@ contains
 
   end subroutine read_parameters
 
-  !==============================================
-  !============== ALLOCATE ARRAYS ===============
-  !==============================================
+  !> Allocate the module-level arrays
   subroutine allocate_arrays
 
     use species, only: nspec
@@ -184,12 +185,10 @@ contains
 
   end subroutine allocate_arrays
 
-  !==============================================
-  !============= OPEN ASCII FILES ===============
-  !==============================================
-  ! Open the '.out' and the '.fluxes' file.
-  ! When running a new simulation, create a new file or replace an old file.
-  ! When restarting a simulation, append the old files.
+  !> Open the '.out' and the '.fluxes' file.
+  !>
+  !> When running a new simulation, create a new file or replace an old file.
+  !> When restarting a simulation, append the old files.
   subroutine open_loop_ascii_files(restart)
 
     use file_utils, only: open_output_file
@@ -230,9 +229,7 @@ contains
 
   end subroutine open_loop_ascii_files
 
-  !==============================================
-  !============= CLOSE ASCII FILES ==============
-  !==============================================
+  !> Close the text files opened by [[open_loop_ascii_files]]
   subroutine close_loop_ascii_files
     
     use file_utils, only: close_output_file
@@ -245,9 +242,7 @@ contains
 
   end subroutine close_loop_ascii_files
 
-  !==============================================
-  !============== DIAGNOSE STELLA ===============
-  !==============================================
+  !> Calculate and write diagnostics
   subroutine diagnose_stella (istep)
 
     use mp, only: proc0
@@ -280,6 +275,7 @@ contains
 
     implicit none
 
+    !> The current timestep
     integer, intent (in) :: istep
     
     real :: phi2, apar2
@@ -444,10 +440,9 @@ contains
 
   end subroutine diagnose_stella
 
-  !==============================================
-  !=============== GET FLUXES ===================
-  !==============================================
-  ! assumes that the non-Boltzmann part of df is passed in (aka h)
+  !> Calculate fluxes
+  !>
+  !> Assumes that the non-Boltzmann part of df is passed in (aka h)
   subroutine get_fluxes (g, pflx, vflx, qflx,&
        pflx_vs_kxkyz, vflx_vs_kxkyz, qflx_vs_kxkyz)
 

--- a/stella_io.fpp
+++ b/stella_io.fpp
@@ -1435,15 +1435,19 @@ contains
 # endif
   end subroutine nc_geo
 
+  !> Get the index of the time dimension in the netCDF file that corresponds to
+  !> a time no larger than `tstart`
   subroutine get_nout(tstart, nout)
 
     use netcdf, only: nf90_inquire_dimension, nf90_get_var
 
     implicit none
 
+    !> Simulation time to find
     real, intent(in) :: tstart
-    real, dimension (:), allocatable :: times
+    !> Index of time dimension
     integer, intent(out) :: nout
+    real, dimension (:), allocatable :: times
     integer :: i, length, status
 
     nout = 1


### PR DESCRIPTION
This adds a Github Action that runs only on pushes to `master`. It runs Ford to build the documentation from `master`, then commits the built documentation to `gh-pages`. This will trigger Github to rebuild the website.

Unfortunately this means there's basically no way to preview the website except building it locally.

I stole the documentation on writing Ford documentation from the GS2 version I wrote: https://gyrokinetics.gitlab.io/gs2/page/developer_manual/writing_documentation.html

The TL;DR is "use `!>` in front of variables/subroutines/functions/modules/programs to turn a comment into a Ford doc-comment".

I've added a small smattering of docstrings to demonstrate what this looks like. They probably want checking.