### PR TITLE
Run a simulation up to code_time=tend.

### DIFF
--- a/run_parameters.f90
+++ b/run_parameters.f90
@@ -134,6 +134,17 @@ contains
        call get_option_value &
             (lu_option, lu_opts, lu_option_switch, ierr, &
             "lu_option in knobs")
+            
+       if (tend<0 .and. nstep<0) then   
+          ierr = error_unit()
+          write (ierr,*) ''
+          write (ierr,*) 'Please specify either <nstep> or <tend> in the <knobs> namelist.'
+          write (ierr,*) 'Aborting.'
+          write (*,*) ''
+          write (*,*) 'Please specify either <nstep> or <tend> in the <knobs> namelist.'
+          write (*,*) 'Aborting.'
+          stop
+       end if
 
     end if
 

--- a/run_parameters.f90
+++ b/run_parameters.f90
@@ -7,7 +7,7 @@ module run_parameters
   public :: init_run_parameters, finish_run_parameters
   public :: fphi, fapar, fbpar
   public :: code_delt_max
-  public :: nstep, delt
+  public :: nstep, tend, delt
   public :: cfl_cushion, delt_adjust
   public :: avail_cpu_time
   public :: stream_implicit, mirror_implicit
@@ -26,7 +26,7 @@ module run_parameters
 
   real :: cfl_cushion, delt_adjust
   real :: fphi, fapar, fbpar
-  real :: delt, code_delt_max
+  real :: delt, tend, code_delt_max
   real :: zed_upwind, vpa_upwind, time_upwind
   logical :: stream_implicit, mirror_implicit
   logical :: driftkinetic_implicit
@@ -83,7 +83,7 @@ contains
 
     integer :: ierr, in_file
 
-    namelist /knobs/ fphi, fapar, fbpar, delt, nstep, &
+    namelist /knobs/ fphi, fapar, fbpar, delt, nstep, tend, &
          delt_option, lu_option, &
          avail_cpu_time, cfl_cushion, delt_adjust, &
          stream_implicit, mirror_implicit, driftkinetic_implicit, &
@@ -120,6 +120,8 @@ contains
        ky_solve_real   = .false.
        mat_gen = .true.
        mat_read = .false.
+       tend = -1.0
+       nstep = -1
 
        in_file = input_unit_exist("knobs", knexist)
        if (knexist) read (unit=in_file, nml=knobs)
@@ -156,6 +158,7 @@ contains
     call broadcast (vpa_upwind)
     call broadcast (time_upwind)
     call broadcast (nstep)
+    call broadcast (tend)
     call broadcast (avail_cpu_time)
     call broadcast (rng_seed)
     call broadcast (ky_solve_radial)

--- a/stella.f90
+++ b/stella.f90
@@ -346,7 +346,6 @@ contains
     if (proc0) then
       write (*,*) ' '
       write (*,*) ' '
-      write (*,*) ''//achar(27)//'[32m'
       write (*,*) "            I8            ,dPYb, ,dPYb,            "
       write (*,*) "            I8            IP'`Yb IP'`Yb            "
       write (*,*) "         88888888         I8  8I I8  8I            "
@@ -356,13 +355,12 @@ contains
       write (*,*) " ,8'  Yb   ,I8,  I8, ,8I  I8P    I8P    i8'    ,8I "
       write (*,*) ",8'_   8) ,d88b, `YbadP' ,d8b,_ ,d8b,_ ,d8,   ,d8b,"
       write (*,*) 'P` "YY8P8P8P""Y8888P"Y8888P`"Y888P`"Y88P"Y8888P"`Y8'
-      write (*,*) ''//achar(27)//'[0m'
       write (*,*) ' '
       write (*,*) ' '
       write (*,*) '                       Version ', VERNUM
       write (*,*) '                        ', VERDATE
       write (*,*) ' '
-      write (*,*) '                     the stella team'
+      write (*,*) '                     The stella team'
       write (*,*) ' '
       write (*,*) '                   University of Oxford'
       write (*,*) ' '

--- a/stella.f90
+++ b/stella.f90
@@ -3,7 +3,7 @@ program stella
   use mp, only: proc0
   use redistribute, only: scatter
   use job_manage, only: time_message, checkstop, job_fork
-  use run_parameters, only: nstep, fphi, fapar
+  use run_parameters, only: nstep, tend, fphi, fapar
   use stella_time, only: update_time, code_time, code_dt
   use dist_redistribute, only: kxkyz2vmu
   use time_advance, only: advance_stella
@@ -47,7 +47,8 @@ program stella
 
   ! Advance stella until istep=nstep
   if (debug) write(*,*) 'stella::advance_stella'
-  do istep = (istep0+1), nstep
+  istep = istep0+1
+  do while ((code_time<=tend .AND. tend>0) .OR. (istep<=nstep .AND. nstep>0)) 
      if (debug) write(*,*) 'istep = ', istep
      if (mod(istep,10)==0) call checkstop (stop_stella)
      if (stop_stella) exit
@@ -62,6 +63,7 @@ program stella
      call time_message(.false.,time_diagnostics,' diagnostics')
      ierr = error_unit()
      call flush_output_file (ierr)
+     istep = istep+1
   end do
 
   ! Finish stella


### PR DESCRIPTION
- Make it possible to run a simulation up to step=nstep or code_time=tend. 

- Removed the colour of the header. I'm not sure with what program the colour is supposed to be visible, but when opening the file with a text editor, all I see is "�[32m", moreover, my computer tries to open these files with skype as the default program due to these characters, so I removed this edit since it doesn't seem compatible with other programs.