### PR TITLE
Add always flag to git describe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,7 @@ check_ford_install:
 	@echo "Ford command $(FORD) not in path -- is it installed?\\n\\tConsider installing with 'pip install --user ford' and add ${HOME}/.local/bin to PATH" ; which $(FORD)
 endif
 
-GIT_VERSION := $(shell git describe --tags --long --match "v*" --first-parent HEAD)
+GIT_VERSION := $(shell git describe --tags --always --long --match "v*" --first-parent HEAD)
 
 doc: docs/stella_docs.md check_ford_install
 	$(FORD) $(INC_FLAGS) -r $(GIT_VERSION) $<


### PR DESCRIPTION
Avoids warnings from git describe in situations not described by a tag. This also allows one to build the docs, currently if git describe fails GIT_VERSION is empty and the ford line then interprets `$<` as the release id rather than the project config.