### PR TITLE
Added delt_max to the <knob> namelist.

### DIFF
--- a/run_parameters.f90
+++ b/run_parameters.f90
@@ -6,9 +6,8 @@ module run_parameters
 
    public :: init_run_parameters, finish_run_parameters
    public :: fphi, fapar, fbpar
-   public :: code_delt_max
    public :: nstep, tend, delt
-   public :: cfl_cushion, delt_adjust
+   public :: cfl_cushion, delt_adjust, delt_max
    public :: avail_cpu_time
    public :: stream_implicit, mirror_implicit
    public :: drifts_implicit
@@ -26,7 +25,7 @@ module run_parameters
 
    real :: cfl_cushion, delt_adjust
    real :: fphi, fapar, fbpar
-   real :: delt, tend, code_delt_max
+   real :: delt, tend, delt_max
    real :: zed_upwind, vpa_upwind, time_upwind
    logical :: stream_implicit, mirror_implicit
    logical :: driftkinetic_implicit
@@ -85,7 +84,7 @@ contains
 
       namelist /knobs/ fphi, fapar, fbpar, delt, nstep, tend, &
          delt_option, lu_option, &
-         avail_cpu_time, cfl_cushion, delt_adjust, &
+         avail_cpu_time, cfl_cushion, delt_adjust, delt_max, &
          stream_implicit, mirror_implicit, driftkinetic_implicit, &
          drifts_implicit, &
          stream_matrix_inversion, maxwellian_inside_zed_derivative, &
@@ -115,6 +114,7 @@ contains
          avail_cpu_time = 1.e10
          cfl_cushion = 0.5
          delt_adjust = 2.0
+         delt_max = -1
          rng_seed = -1 !negative values use current time as seed
          ky_solve_radial = 0
          ky_solve_real = .false.
@@ -154,6 +154,7 @@ contains
       call broadcast(lu_option_switch)
       call broadcast(cfl_cushion)
       call broadcast(delt_adjust)
+      call broadcast(delt_max)
       call broadcast(fphi)
       call broadcast(fapar)
       call broadcast(fbpar)
@@ -178,8 +179,6 @@ contains
       call broadcast(mat_read)
 
       if (.not. include_mirror) mirror_implicit = .false.
-
-      code_delt_max = delt
 
       if (driftkinetic_implicit) then
          stream_implicit = .false.

--- a/stella.f90
+++ b/stella.f90
@@ -76,7 +76,7 @@ contains
       use physics_parameters, only: init_physics_parameters
       use physics_flags, only: init_physics_flags, radial_variation
       use run_parameters, only: init_run_parameters
-      use run_parameters, only: avail_cpu_time, nstep, rng_seed, delt
+      use run_parameters, only: avail_cpu_time, nstep, rng_seed, delt, delt_max
       use run_parameters, only: stream_implicit, driftkinetic_implicit
       use run_parameters, only: delt_option_switch, delt_option_auto
       use run_parameters, only: mat_gen, mat_read
@@ -288,7 +288,7 @@ contains
       end if
       !> set the internal time step size variable code_dt from the input variable delt
       if (debug) write (6, *) "stella::init_stella::init_delt"
-      call init_delt(delt)
+      call init_delt(delt, delt_max)
       !> allocate and calculate arrays needed for the mirror, parallel streaming,
       !> magnetic drifts, gradient drive, etc. terms during time advance
       if (debug) write (6, *) 'stella::init_stella::init_time_advance'

--- a/stella_time.f90
+++ b/stella_time.f90
@@ -30,13 +30,20 @@ contains
 
    end subroutine init_tstart
 
-   subroutine init_delt(delt)
-      real, intent(in) :: delt
+   subroutine init_delt(delt, delt_max)
+      real, intent(in) :: delt, delt_max
 
       code_dt = delt
-      ! do not allow code_dt to increase beyond input value
-      code_dt_max = code_dt
-
+      
+      ! Do not allow code_dt to increase beyond the input value
+      ! Unless we specified delt_max in the input file
+      ! For example, when restarting the simulation
+      if (delt_max < 0) then
+          code_dt_max = code_dt
+      else
+          code_dt_max = delt_max
+      end if
+      
    end subroutine init_delt
 
    subroutine update_time

--- a/time_advance.f90
+++ b/time_advance.f90
@@ -1808,8 +1808,8 @@ contains
             write (*, '(A16, ES10.2E2)') "   cfl_dt:"//REPEAT(' ', 50), cfl_dt
             write (*, '(A16, ES10.2E2)') "   cfl_cushion:"//REPEAT(' ', 50), cfl_cushion
             write (*, '(A16, ES10.2E2)') "   delt_adjust:"//REPEAT(' ', 50), delt_adjust
-            write (*, '(A65)') '     ==> User-specified delt is larger than cfl_dt*cfl_cushion.'//REPEAT(' ', 50)
-        write (*, '(A61,ES12.4)') '     ==> Changing code_dt to cfl_dt*cfl_cushion/delt_adjust ='//REPEAT(' ', 50), cfl_dt * cfl_cushion / delt_adjust
+            write (*, '(A65)') '     ==> The code_dt is larger than cfl_dt*cfl_cushion.'//REPEAT(' ', 50)
+        write (*, '(A61,ES12.4)') '     ==> Decreasing code_dt to cfl_dt*cfl_cushion/delt_adjust ='//REPEAT(' ', 50), cfl_dt * cfl_cushion / delt_adjust
             write (*, *) ' '
          end if
          code_dt = cfl_dt * cfl_cushion / delt_adjust
@@ -1823,8 +1823,8 @@ contains
             write (*, '(A16, ES10.2E2)') "   cfl_dt:"//REPEAT(' ', 50), cfl_dt
             write (*, '(A16, ES10.2E2)') "   cfl_cushion:"//REPEAT(' ', 50), cfl_cushion
             write (*, '(A16, ES10.2E2)') "   delt_adjust:"//REPEAT(' ', 50), delt_adjust
-            write (*, '(A65)') '     ==> User-specified delt is larger than cfl_dt*cfl_cushion.'//REPEAT(' ', 50)
-        write (*, '(A61,ES12.4)') '     ==> Changing code_dt to cfl_dt*cfl_cushion/delt_adjust ='//REPEAT(' ', 50), cfl_dt * cfl_cushion / delt_adjust
+            write (*, '(A65)') '     ==> The code_dt is smaller than cfl_dt*cfl_cushion.'//REPEAT(' ', 50)
+        write (*, '(A61,ES12.4)') '     ==> Increasing code_dt to cfl_dt*cfl_cushion/delt_adjust ='//REPEAT(' ', 50), cfl_dt * cfl_cushion / delt_adjust
             write (*, *) ' '
          end if
          code_dt = min(cfl_dt * cfl_cushion / delt_adjust, code_dt_max)
@@ -2122,8 +2122,8 @@ contains
             write (*, '(A16, ES10.2E2)') "   cfl_dt:"//REPEAT(' ', 50), cfl_dt
             write (*, '(A16, ES10.2E2)') "   cfl_cushion:"//REPEAT(' ', 50), cfl_cushion
             write (*, '(A16, ES10.2E2)') "   delt_adjust:"//REPEAT(' ', 50), delt_adjust
-            write (*, '(A65)') '     ==> User-specified delt is larger than cfl_dt*cfl_cushion.'//REPEAT(' ', 50)
-        write (*, '(A61,ES12.4)') '     ==> Changing code_dt to cfl_dt*cfl_cushion/delt_adjust ='//REPEAT(' ', 50), cfl_dt * cfl_cushion / delt_adjust
+            write (*, '(A65)') '     ==> The code_dt is larger than cfl_dt*cfl_cushion.'//REPEAT(' ', 50)
+        write (*, '(A61,ES12.4)') '     ==> Decreasing code_dt to cfl_dt*cfl_cushion/delt_adjust ='//REPEAT(' ', 50), cfl_dt * cfl_cushion / delt_adjust
             write (*, *) ' '
          end if
          code_dt = cfl_dt * cfl_cushion / delt_adjust
@@ -2137,8 +2137,8 @@ contains
             write (*, '(A16, ES10.2E2)') "   cfl_dt:"//REPEAT(' ', 50), cfl_dt
             write (*, '(A16, ES10.2E2)') "   cfl_cushion:"//REPEAT(' ', 50), cfl_cushion
             write (*, '(A16, ES10.2E2)') "   delt_adjust:"//REPEAT(' ', 50), delt_adjust
-            write (*, '(A65)') '     ==> User-specified delt is larger than cfl_dt*cfl_cushion.'//REPEAT(' ', 50)
-        write (*, '(A61,ES12.4)') '     ==> Changing code_dt to cfl_dt*cfl_cushion/delt_adjust ='//REPEAT(' ', 50), cfl_dt * cfl_cushion / delt_adjust
+            write (*, '(A65)') '     ==> The code_dt is smaller than cfl_dt*cfl_cushion.'//REPEAT(' ', 50)
+        write (*, '(A61,ES12.4)') '     ==> Increasing code_dt to cfl_dt*cfl_cushion/delt_adjust ='//REPEAT(' ', 50), cfl_dt * cfl_cushion / delt_adjust
             write (*, *) ' '
          end if
          code_dt = min(cfl_dt * cfl_cushion / delt_adjust, code_dt_max)


### PR DESCRIPTION
Before the maximum time step was the <delt> given in the <knob> namelist. However when we restart we do not want the restarted time step to be the maximum time step. Therefore I added a new variable <delt_max> which will set the maximum time step. If it is not mentioned, the previous behaviour of code_delt_max = delt will be retained.