### PR TITLE
Always mpi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ mp.f90
 mp_lu_decomposition.f90
 fields.f90
 sources.f90
-multibox.f90
 netcdf_utils.f90
 ran.f90
 response_matrix.f90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(STELLA_SOURCES_f90
   init_g.f90
   kt_grids.f90
   mirror_terms.f90
+  multibox.f90
   neoclassical_terms.f90
   parallel_streaming.f90
   physics_flags.f90
@@ -75,7 +76,6 @@ set(STELLA_SOURCES_f90
 # Sources that _do_ need preprocessing
 set(STELLA_SOURCES_fpp
   fields.fpp
-  multibox.fpp
   response_matrix.fpp
   sfincs_interface.fpp
   sources.fpp

--- a/Makefiles/Makefile.T3E
+++ b/Makefiles/Makefile.T3E
@@ -1,5 +1,4 @@
 # T3E (is this still used?)
-USE_MPI = on
 FC = f90
 #USE_SHMEM = on
 override USE_POSIX = on
@@ -8,10 +7,8 @@ override USE_POSIX = on
 F90FLAGS = -M1110,7212
 CPPFLAGS += -DFCOMPILER=_CRAY_
 
-ifdef USE_MPI
-	MPI_INC = -I$$MPTDIR/include 
-	MPI_LIB = -lmpi
-endif
+MPI_INC = -I$$MPTDIR/include 
+MPI_LIB = -lmpi
 
 NETCDF_LIB = $$NETCDF -Wl"-D permok=yes"
 

--- a/Makefiles/Makefile.archer2
+++ b/Makefiles/Makefile.archer2
@@ -8,7 +8,6 @@ helplocal:
 		#
 		#   ARCHER defaults : cray compiler, FFTW3, netcdf, MPI
 		#   ARCHER single restart: cray compiler
-		# make FRONT_END=on : serial build (no MPI) to run gs2, ingen on ARCHER Front End.
 
 define STANDARD_SYSTEM_CONFIGURATION
 module restore PrgEnv-gnu ;\
@@ -30,12 +29,6 @@ endif
 
 CHIP=ivy-bridge
 CRAY_SYSTEM=true
-
-ifdef FRONT_END
-      STATIC = on
-      override USE_MPI = 
-      override USE_HDF5 =
-endif
 
 # switch on netcdf
 ifdef NETCDF_DIR
@@ -62,10 +55,8 @@ include Makefile.$(COMPILER)
 
 FC=ftn
 CC=cc
-ifdef USE_MPI
-	MPIFC=ftn
-	MPICC=cc
-endif
+MPIFC=ftn
+MPICC=cc
 
 # For CRAY machines, this convention is always followed. Do not change without 
 # good reason!

--- a/Makefiles/Makefile.bigben
+++ b/Makefiles/Makefile.bigben
@@ -23,10 +23,8 @@ include Makefile.$(COMPILER)
 
 FC=ftn
 CC=cc
-ifdef USE_MPI
-	MPIFC=ftn
-	MPICC=cc
-endif
+MPIFC=ftn
+MPICC=cc
 
 ifeq ($(USE_FFT),fftw)
 	FFT_INC = -I/usr/local/packages/fftw-2.1.5/pgi/include

--- a/Makefiles/Makefile.bsc
+++ b/Makefiles/Makefile.bsc
@@ -28,10 +28,8 @@ include Makefile.$(COMPILER)
 
 FC=f90
 CC=icc
-ifdef USE_MPI
-	MPIFC=mpiifort
-	MPICC=mpiicc
-endif
+MPIFC=mpiifort
+MPICC=mpiicc
 
 ifeq ($(USE_FFT),fftw3)	
 	FFT_INC = 

--- a/Makefiles/Makefile.davinci
+++ b/Makefiles/Makefile.davinci
@@ -33,11 +33,9 @@ endif
 
 include Makefile.$(COMPILER)
 
-ifdef USE_MPI
-	MPIFC := $(FC)
-	MPICC := $(CC)
-	LIBS	+= -lmpi
-endif
+MPIFC := $(FC)
+MPICC := $(CC)
+LIBS	+= -lmpi
 
 ifeq ($(USE_FFT),fftw)
 	FFT_INC = $$FFTW

--- a/Makefiles/Makefile.dirac
+++ b/Makefiles/Makefile.dirac
@@ -33,10 +33,8 @@ include Makefile.$(COMPILER)
 
 FC=ifort
 CC=icc
-ifdef USE_MPI
-	MPIFC=mpiifort
-	MPICC=mpiicc
-endif
+MPIFC=mpiifort
+MPICC=mpiicc
 
 ifeq ($(USE_FFT),fftw3)	
 	FFT_INC = 

--- a/Makefiles/Makefile.edison
+++ b/Makefiles/Makefile.edison
@@ -11,7 +11,6 @@ helplocal:
 		#   ARCHER defaults : intel compiler, FFTW3, netcdf, MPI
 		#   ARCHER single restart: intel compiler, cray-netcdf-hdf5parallel, 
 		#   					   cray-hdf5-parallel, fftw3
-		# make FRONT_END=on : serial build (no MPI) to run gs2, ingen on ARCHER Front End.
 
 define STANDARD_SYSTEM_CONFIGURATION
 module unload PrgEnv-cray; \
@@ -37,11 +36,6 @@ endef
 COMPILER=intel
 CHIP=ivy-bridge
 CRAY_SYSTEM=true
-
-ifdef FRONT_END
-      STATIC = on
-      override USE_MPI = 
-endif
 
 ifdef FFTW_DIR
 	USE_FFT = fftw3
@@ -79,10 +73,8 @@ include Makefile.$(COMPILER)
 
 FC=ftn
 CC=cc
-ifdef USE_MPI
-	MPIFC=ftn
-	MPICC=cc
-endif
+MPIFC=ftn
+MPICC=cc
 
 # For CRAY machines, this convention is always followed. Do not change without 
 # good reason!

--- a/Makefiles/Makefile.euler
+++ b/Makefiles/Makefile.euler
@@ -9,7 +9,6 @@ COMPILER=intel
 
 USE_FFT = fftw3
 USE_NETCDF = on
-USE_MPI= on
 
 # This line disables the automated checking
 # of the intel version which is slow
@@ -19,13 +18,10 @@ include Makefile.$(COMPILER)
 
 FC=ifort
 CC=icc
-ifdef USE_MPI
-	MPIFC=mpif90
-	MPICC=mpiicc
-	MPI_INC=-I$(MPI_ROOT)/include/
-  	MPI_LIB=-L$(MPI_ROOT)/lib/
-	#MPI_LIB=-lmpi
-endif
+MPIFC=mpif90
+MPICC=mpiicc
+MPI_INC=-I$(MPI_ROOT)/include/
+MPI_LIB=-L$(MPI_ROOT)/lib/
 
 ifeq ($(USE_FFT),fftw3)	
 	FFT_INC = 

--- a/Makefiles/Makefile.franklin
+++ b/Makefiles/Makefile.franklin
@@ -54,10 +54,8 @@ include Makefile.$(COMPILER)
 
 FC=ftn
 CC=cc
-ifdef USE_MPI
-	MPIFC = ftn
-	MPICC = cc
-endif
+MPIFC = ftn
+MPICC = cc
 ifdef CRAY_HDF5
 	H5FC = ftn
 	H5FC_par = ftn

--- a/Makefiles/Makefile.homer
+++ b/Makefiles/Makefile.homer
@@ -5,6 +5,5 @@ COMPILER= nag
 
 override USE_FFT=
 override USE_NETCDF=
-override USE_MPI=
 
 include Makefile.$(COMPILER)

--- a/Makefiles/Makefile.ist
+++ b/Makefiles/Makefile.ist
@@ -5,10 +5,8 @@ COMPILER=xl
 
 include Makefile.$(COMPILER)
 
-ifdef USE_MPI
-	MPIFC = mpxlf90
-	MPICC = mpcc
-endif
+MPIFC = mpxlf90
+MPICC = mpcc
 
 FFT_INC = -I${HOME}/local/include
 FFT_LIB = -L${HOME}/local/lib -lrfftw -lfftw

--- a/Makefiles/Makefile.jaguarpf
+++ b/Makefiles/Makefile.jaguarpf
@@ -52,10 +52,8 @@ include Makefile.$(COMPILER)
 
 FC=ftn
 CC=cc
-ifdef USE_MPI
-	MPIFC = ftn
-	MPICC = cc
-endif
+MPIFC = ftn
+MPICC = cc
 ifdef CRAY_HDF5
 	H5FC = ftn
 	H5FC_par = ftn

--- a/Makefiles/Makefile.kestrel
+++ b/Makefiles/Makefile.kestrel
@@ -19,9 +19,7 @@ endif
 
 include Makefile.$(COMPILER)
 
-ifdef USE_MPI
-	LIBS += -lmpichf90
-endif
+LIBS += -lmpichf90
 
 ifeq ($(USE_FFT),fftw)
 	FFT_INC = -I${FFTWHOME}/include

--- a/Makefiles/Makefile.kraken
+++ b/Makefiles/Makefile.kraken
@@ -74,10 +74,8 @@ include Makefile.$(COMPILER)
 
 FC=ftn
 CC=cc
-ifdef USE_MPI
-	MPIFC = ftn
-	MPICC = cc
-endif
+MPIFC = ftn
+MPICC = cc
 
 ifdef CRAY_HDF5
 	H5FC = ftn

--- a/Makefiles/Makefile.macports
+++ b/Makefiles/Makefile.macports
@@ -29,14 +29,6 @@ include Makefile.$(COMPILER)
 F90FLAGS += -m64 -Wall
 CFLAGS += -m64
 
-ifdef FRONT_END
-      override USE_MPI = 
-endif
-
-USE_LOCAL_SPFUNC=on
-
-MPIFC=openmpif90
-
 USE_LOCAL_SPFUNC=on
 
 ifeq ($(USE_FFT),fftw)
@@ -59,8 +51,5 @@ endif
 
 FC=gfortran
 CC=gcc
-ifdef USE_MPI
-	MPIFC=openmpif90
-	MPICC=openmpicc
-endif
-
+MPIFC=openmpif90
+MPICC=openmpicc

--- a/Makefiles/Makefile.marconi
+++ b/Makefiles/Makefile.marconi
@@ -37,10 +37,8 @@ include Makefile.$(COMPILER)
 
 FC=ifort
 CC=icc
-ifdef USE_MPI
-	MPIFC=mpiifort
-	MPICC=mpiicc
-endif
+MPIFC=mpiifort
+MPICC=mpiicc
 
 ifeq ($(USE_FFT),fftw3)	
 	FFT_INC = 

--- a/Makefiles/Makefile.mn4
+++ b/Makefiles/Makefile.mn4
@@ -19,7 +19,6 @@ endef
 
 COMPILER=intel
 
-USE_MPI=on
 USE_FFT = fftw3
 USE_NETCDF = on
 
@@ -31,10 +30,8 @@ include Makefile.$(COMPILER)
 
 FC=mpiifort
 CC=icc
-ifdef USE_MPI
-	MPIFC=mpiifort
-	MPICC=mpiicc
-endif
+MPIFC=mpiifort
+MPICC=mpiicc
 
 ifeq ($(USE_FFT),fftw3)	
 	FFT_INC =
@@ -55,11 +52,7 @@ ifdef USE_NETCDF
   NETCDF_LIB= -L $(NETCDF_DIR)/lib/ -lnetcdff -L$(NETCDF_HOME)/lib/ -lnetcdf
 endif
 
-ifdef USE_MPI
-  #MPI_INC=-I$(MPI_ROOT)/intel64/include/
-  MPI_INC=-I$(MPI_ROOT)/include64/
-  MPI_LIB=-lmpi
-endif
+MPI_INC=-I$(MPI_ROOT)/include64/
+MPI_LIB=-lmpi
 
-$(warning USE_MPI=$(USE_MPI))
 $(warning USE_NETCDF=$(USE_NETCDF))

--- a/Makefiles/Makefile.pleaides
+++ b/Makefiles/Makefile.pleaides
@@ -25,12 +25,10 @@ USE_HDF5 =
 MPIINC = on
 include Makefile.$(COMPILER)
 
-ifdef USE_MPI
-	MPIFC := $(FC)
-	MPICC := $(CC)
-	LIBS	+= -lmpi
-	F90FLAGS += -I/nasa/sgi/mpt/1.25/include
-endif
+MPIFC := $(FC)
+MPICC := $(CC)
+LIBS	+= -lmpi
+F90FLAGS += -I/nasa/sgi/mpt/1.25/include
 
 ifeq ($(USE_FFT),mkl_fftw)
 	FFT_LIB = -L/nasa/intel/Compiler/11.1/046 -lfftw2xf_intel  -lmkl_core -lmkl_intel_lp64 -lmkl_sequential

--- a/Makefiles/Makefile.rokko
+++ b/Makefiles/Makefile.rokko
@@ -10,11 +10,9 @@ endif
 
 include Makefile.$(COMPILER)
 
-ifdef USE_MPI
 ifdef USE_MIC
 	MPIFC = mpiifort
 	MPICC = mpiicc
-endif
 endif
 
 USE_HDF5=on

--- a/Makefiles/Makefile.tungsten
+++ b/Makefiles/Makefile.tungsten
@@ -6,9 +6,7 @@ CHIP=xeon
 
 include Makefile.$(COMPILER)
 
-ifdef USE_MPI
-	MPIFC = cmpif90c
-endif
+MPIFC = cmpif90c
 
 ifeq ($(USE_FFT),fftw)
 	FFT_LIB = -L$$FFTW_HOME/lib -ldrfftw -ldfftw

--- a/Makefiles/Makefile.xula
+++ b/Makefiles/Makefile.xula
@@ -19,14 +19,11 @@ include Makefile.$(COMPILER)
 FC=ifort
 CC=icc
 
-ifdef USE_MPI
-	MPIFC=mpifort
-	MPICC=mpiicc
-	MPIFC=mpif90
-	MPI_HOME=/mnt/lustre/ohpc/admin/spack/0.12.1/opt/spack/linux-centos7-x86_64/intel-19.0.5.281/openmpi-3.1.3-xnwkw7bcmpsrdymg77auoyudr2pr3mu5
-	MPI_INC=-I$(MPI_HOME)/include/
-	MPI_LIB=-L$(MPI_HOME)/lib/
-endif
+MPIFC=mpifort
+MPICC=mpiicc
+MPIFC=mpif90
+MPI_HOME=/mnt/lustre/ohpc/admin/spack/0.12.1/opt/spack/linux-centos7-x86_64/intel-19.0.5.281/openmpi-3.1.3-xnwkw7bcmpsrdymg77auoyudr2pr3mu5
+MPI_INC=-I$(MPI_HOME)/include/	MPI_LIB=-L$(MPI_HOME)/lib/
 
 ifeq ($(USE_FFT),fftw3)	
      	FFT_DIR=/mnt/lustre/ohpc/admin/spack/0.12.1/opt/spack/linux-centos7-x86_64/intel-19.0.5.281/fftw-3.3.8-ymonpurwnnwrjsw3zw4kh5d7brp2sbn6

--- a/multibox.f90
+++ b/multibox.f90
@@ -335,7 +335,7 @@ contains
          rho_mb_clamped = rho_d_clamped
          return
       end if
-#ifdef MPI
+
       call scope(crossdomprocs)
 
       dx_mb = (2 * pi * x0) / x_fft_size
@@ -423,7 +423,6 @@ contains
       end if
 
       call scope(subprocs)
-#endif
 
    end subroutine init_multibox
 
@@ -434,7 +433,6 @@ contains
 
       implicit none
 
-#ifdef MPI
       if (job == 1) then
          call scope(crossdomprocs)
 
@@ -447,7 +445,7 @@ contains
          call scope(subprocs)
 
       end if
-#endif
+
    end subroutine communicate_multibox_parameters
 
    subroutine finish_multibox
@@ -507,9 +505,6 @@ contains
       complex, dimension(:, :), allocatable :: prefac
       complex, dimension(:, :, -nzgrid:, :, vmu_lo%llim_proc:), intent(inout) :: gin
 
-#ifndef MPI
-      return
-#else
       if (runtype_option_switch /= runtype_multibox) return
       if (LR_debug_switch /= LR_debug_option_default) return
       if (njobs /= 3) call mp_abort("Multibox only supports 3 domains at the moment.")
@@ -664,7 +659,6 @@ contains
 
       if (proc0) call time_message(.false., time_multibox(:, 1), ' mb_comm')
 
-#endif
    end subroutine multibox_communicate
 
    subroutine apply_radial_boundary_conditions(gin)

--- a/response_matrix.fpp
+++ b/response_matrix.fpp
@@ -14,7 +14,7 @@ module response_matrix
    logical :: response_matrix_initialized = .false.
    integer, parameter :: mat_unit = 70
 
-#if defined MPI && defined ISO_C_BINDING
+#ifdef ISO_C_BINDING
    integer :: window = MPI_WIN_NULL
 #endif
 
@@ -37,7 +37,7 @@ contains
       use run_parameters, only: mat_gen, lu_option_switch
       use run_parameters, only: lu_option_none, lu_option_local, lu_option_global
       use system_fortran, only: systemf
-#if defined MPI && defined ISO_C_BINDING
+#ifdef ISO_C_BINDING
       use, intrinsic :: iso_c_binding, only: c_ptr, c_f_pointer, c_intptr_t
       use mp, only: curr_focus, sgproc0, mp_comm, sharedsubprocs, scope, barrier
       use mp, only: real_size, nbytes_real
@@ -51,7 +51,7 @@ contains
       integer :: nz_ext, nresponse
       integer :: idx
       integer :: izl_offset, izup
-#if defined MPI && defined ISO_C_BINDING
+#ifdef ISO_C_BINDING
       integer :: prior_focus, ierr
       integer :: disp_unit = 1
       integer(kind=MPI_ADDRESS_KIND) :: win_size
@@ -106,7 +106,7 @@ contains
 
       if (.not. allocated(response_matrix)) allocate (response_matrix(naky))
 
-#if defined ISO_C_BINDING && defined MPI
+#ifdef ISO_C_BINDING
 
 !   Create a single shared memory window for all the response matrices and
 !   permutation arrays.
@@ -183,19 +183,7 @@ contains
                write (unit=mat_unit) ie, nresponse
             end if
 
-#if !defined ISO_C_BINDING || !defined MPI
-            ! for each ky and set of connected kx values,
-            ! must have a response matrix that is N x N
-            ! with N = number of zeds per 2pi segment x number of 2pi segments
-            if (.not. associated(response_matrix(iky)%eigen(ie)%zloc)) &
-               allocate (response_matrix(iky)%eigen(ie)%zloc(nresponse, nresponse))
-
-            ! response_matrix%idx is needed to keep track of permutations
-            ! to the response matrix made during LU decomposition
-            ! it will be input to LU back substitution during linear solve
-            if (.not. associated(response_matrix(iky)%eigen(ie)%idx)) &
-               allocate (response_matrix(iky)%eigen(ie)%idx(nresponse))
-#else
+#ifdef ISO_C_BINDING 
             !exploit MPIs shared memory framework to reduce memory consumption of
             !response matrices
 
@@ -210,6 +198,18 @@ contains
                call c_f_pointer(cptr, response_matrix(iky)%eigen(ie)%idx, (/nresponse/))
                cur_pos = cur_pos + nresponse * 4
             end if
+#else
+            ! for each ky and set of connected kx values,
+            ! must have a response matrix that is N x N
+            ! with N = number of zeds per 2pi segment x number of 2pi segments
+            if (.not. associated(response_matrix(iky)%eigen(ie)%zloc)) &
+               allocate (response_matrix(iky)%eigen(ie)%zloc(nresponse, nresponse))
+
+            ! response_matrix%idx is needed to keep track of permutations
+            ! to the response matrix made during LU decomposition
+            ! it will be input to LU back substitution during linear solve
+            if (.not. associated(response_matrix(iky)%eigen(ie)%idx)) &
+               allocate (response_matrix(iky)%eigen(ie)%idx(nresponse))
 #endif
 
             allocate (gext(nz_ext, vmu_lo%llim_proc:vmu_lo%ulim_alloc))
@@ -276,7 +276,7 @@ contains
 
          ! loop over the sets of connected kx values
          do ie = 1, neigen(iky)
-#if defined ISO_C_BINDING && defined MPI
+#ifdef ISO_C_BINDING
             if (sgproc0) then
 #endif
                ! number of zeds x number of segments
@@ -306,7 +306,7 @@ contains
 
                end do
                deallocate (phiext)
-#if defined ISO_C_BINDING && defined MPI
+#ifdef ISO_C_BINDING
             end if
 #endif
          end do
@@ -321,7 +321,6 @@ contains
          end if
 
          !now we have the full response matrix. Finally, perform its LU decomposition
-#ifdef MPI
          select case (lu_option_switch)
          case (lu_option_global)
             call parallel_LU_decomposition_global(iky)
@@ -332,7 +331,6 @@ contains
             call mp_abort('Stella must be built with HAS_ISO_BINDING in order to use local parallel LU decomposition.')
 #endif
          case default
-#endif
             do ie = 1, neigen(iky)
 #ifdef ISO_C_BINDING
                if (sgproc0) then
@@ -346,9 +344,7 @@ contains
                end if
 #endif
             end do
-#ifdef MPI
          end select
-#endif
 
          if (proc0 .and. debug) then
             call time_message(.true., time_response_matrix_lu, message_lu)
@@ -502,7 +498,7 @@ contains
       use parallel_streaming, only: stream_tridiagonal_solve
       use parallel_streaming, only: stream_sign
       use run_parameters, only: zed_upwind, time_upwind
-#if defined ISO_C_BINDING && defined MPI
+#ifdef ISO_C_BINDING
       use mp, only: sgproc0
 #endif
 
@@ -783,10 +779,10 @@ contains
       !  copy of phiext)
       call integrate_over_velocity(gext, phiext, iky, ie)
 
-#if !defined ISO_C_BINDING || !defined MPI
-      response_matrix(iky)%eigen(ie)%zloc(:, idx) = phiext(:nresponse)
-#else
+#ifdef ISO_C_BINDING
       if (sgproc0) response_matrix(iky)%eigen(ie)%zloc(:, idx) = phiext(:nresponse)
+#else
+      response_matrix(iky)%eigen(ie)%zloc(:, idx) = phiext(:nresponse)
 #endif
 
    end subroutine get_dgdphi_matrix_column
@@ -974,7 +970,6 @@ contains
 
    end subroutine finish_response_matrix
 
-#ifdef MPI
 !----------------------------------------------------------!
 ! !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! !
 ! !!!!!!!!!!!!!!PARALLEL LU DECOMPOSITIONS!!!!!!!!!!!!!!!! !
@@ -1405,7 +1400,5 @@ contains
 #endif
       deallocate (job_roots)
    end subroutine parallel_LU_decomposition_global
-
-#endif /* MPI */
 
 end module response_matrix

--- a/response_matrix.fpp
+++ b/response_matrix.fpp
@@ -183,7 +183,7 @@ contains
                write (unit=mat_unit) ie, nresponse
             end if
 
-#ifdef ISO_C_BINDING 
+#ifdef ISO_C_BINDING
             !exploit MPIs shared memory framework to reduce memory consumption of
             !response matrices
 

--- a/sources.fpp
+++ b/sources.fpp
@@ -1,6 +1,6 @@
 module sources
 
-#if defined MPI && defined ISO_C_BINDING
+#ifdef ISO_C_BINDING
    use mpi
 #endif
 
@@ -33,7 +33,7 @@ module sources
 
    logical :: debug = .false.
 
-#if defined MPI && defined ISO_C_BINDING
+#ifdef ISO_C_BINDING
    logical :: qn_window_initialized = .false.
 #endif
 
@@ -184,7 +184,7 @@ contains
 
       use dist_fn_arrays, only: g_krook, g_proj, g_symm
       use fields_arrays, only: phi_proj, phi_proj_stage
-#if defined MPI && defined ISO_C_BINDING
+#ifdef ISO_C_BINDING
       use fields_arrays, only: qn_zf_window
 #else
       use fields_arrays, only: phizf_solve, phi_ext
@@ -200,7 +200,7 @@ contains
       if (allocated(phi_proj)) deallocate (phi_proj)
       if (allocated(phi_proj_stage)) deallocate (phi_proj_stage)
 
-#if defined MPI && defined ISO_C_BINDING
+#ifdef ISO_C_BINDING
       if (qn_window_initialized .and. qn_zf_window /= MPI_WIN_NULL) then
          call mpi_win_free(qn_zf_window, ierr)
          qn_window_initialized = .false.
@@ -651,7 +651,7 @@ contains
 
    subroutine init_quasineutrality_source
 
-#if defined MPI && defined ISO_C_BINDING
+#ifdef ISO_C_BINDING
       use, intrinsic :: iso_c_binding, only: c_ptr, c_f_pointer, c_intptr_t
       use fields_arrays, only: qn_zf_window
       use mp, only: sgproc0, curr_focus, mp_comm, sharedsubprocs, comm_sgroup
@@ -672,7 +672,7 @@ contains
       integer :: iz, ikx, ia, jkx, jz
       integer :: inmat, jnmat, nmat_zf
       real :: dum
-#if defined MPI && ISO_C_BINDING
+#ifdef ISO_C_BINDING
       integer :: prior_focus, ierr, temp_window
       integer :: disp_unit = 1
       integer(c_intptr_t):: cur_pos
@@ -689,7 +689,7 @@ contains
 
       if (include_qn_source) then
          nmat_zf = nakx * (nztot - 1)
-#if defined MPI && ISO_C_BINDING
+#ifdef ISO_C_BINDING
          if ((.not. qn_window_initialized) .or. (qn_zf_window == MPI_WIN_NULL)) then
             prior_focus = curr_focus
             call scope(sharedsubprocs)
@@ -741,7 +741,7 @@ contains
          if (.not. associated(phi_ext)) allocate (phi_ext(nmat_zf))
 #endif
 
-#if defined MPI && ISO_C_BINDING
+#ifdef ISO_C_BINDING
          if (sgproc0) then
 #endif
             allocate (g0k(1, nakx))
@@ -818,7 +818,7 @@ contains
                end do
             end do
             deallocate (g0k, g1k, g0x)
-#if defined MPI && ISO_C_BINDING
+#ifdef ISO_C_BINDING
          end if
 
          call mpi_win_fence(0, qn_zf_window, ierr)

--- a/utils/job_manage.fpp
+++ b/utils/job_manage.fpp
@@ -24,7 +24,6 @@ contains
 # endif
       real :: timer_local
 
-
       timer_local = 0.
 
       timer_local = mpi_wtime()

--- a/utils/job_manage.fpp
+++ b/utils/job_manage.fpp
@@ -17,24 +17,17 @@ contains
 
 !!! returns CPU time in second
    function timer_local()
-# ifdef MPI
 # ifndef MPIINC
       use mpi, only: mpi_wtime
 # else
       include "mpif.h" ! CMR following Michele Weiland's advice
 # endif
-
-# endif
       real :: timer_local
+
 
       timer_local = 0.
 
-# ifdef MPI
       timer_local = mpi_wtime()
-# else
-      ! this routine is F95 standard
-      call cpu_time(timer_local)
-# endif
 
    end function timer_local
 

--- a/utils/mp.fpp
+++ b/utils/mp.fpp
@@ -1889,7 +1889,6 @@ contains
 
    end subroutine mp_abort
 
-
    ! this gathers a single integer from each processor into an array on proc0
    subroutine mp_gather(senddata, recvarray)
 

--- a/utils/mp_lu_decomposition.fpp
+++ b/utils/mp_lu_decomposition.fpp
@@ -1,6 +1,6 @@
 module mp_lu_decomposition
 
-#if defined MPI && ISO_C_BINDING
+#ifdef ISO_C_BINDING
 
    implicit none
 


### PR DESCRIPTION
Hello Peter. Since we always seem to compile with MPI enabled, I removed it as a compiler directive for Makefiles. Does anything need to be changed with CMake?