### PR TITLE
Stellarator symmetric twist and shift BC (bug and new functionality)

### DIFF
--- a/geo/vmec_interface/test_vmec_to_stella_geometry_interface.f90
+++ b/geo/vmec_interface/test_vmec_to_stella_geometry_interface.f90
@@ -44,7 +44,7 @@ program test_vmec_to_stella_geometry_interface
    ! Beginning of executable statements
    !*********************************************************************
 
-   call read_vmec_equilibrium(vmec_filename)
+   call read_vmec_equilibrium(vmec_filename, verbose)
 
    call vmec_to_stella_geometry_interface(nalpha, alpha0, nzgrid, zeta_center, &
                                           number_of_field_periods_to_include, &

--- a/geo/vmec_interface/vmec_to_stella_geometry_interface.f90
+++ b/geo/vmec_interface/vmec_to_stella_geometry_interface.f90
@@ -12,6 +12,7 @@ module vmec_to_stella_geometry_interface_mod
    public :: vmec_to_stella_geometry_interface
    public :: get_nominal_vmec_zeta_grid
    public :: read_vmec_equilibrium
+   public :: desired_zmin
 
    real :: theta_pest_target, zeta0
    real, dimension(2) :: vmec_radial_weight_full, vmec_radial_weight_half
@@ -38,7 +39,7 @@ module vmec_to_stella_geometry_interface_mod
 
 contains
 
-   subroutine read_vmec_equilibrium(vmec_filename)
+   subroutine read_vmec_equilibrium(vmec_filename, verbose)
 
       use read_wout_mod, only: read_wout_file, read_wout_deallocate
       use read_wout_mod, only: nfp_vmec => nfp
@@ -83,6 +84,7 @@ contains
       implicit none
 
       ! vmec_filename is the vmec wout_* file that will be read.
+      logical, intent(in) :: verbose
       character(*), intent(in) :: vmec_filename
 
       integer :: ierr, iopen
@@ -91,14 +93,18 @@ contains
       ! Read in everything from the vmec wout file using libstell.
       !*********************************************************************
 
-      write (*, '(A)') "############################################################"
-      write (*, '(A)') "                       MAGNETIC FIELD"
-      write (*, '(A)') "############################################################"
-      write (*, *) "About to read VMEC wout file: '", trim(vmec_filename), "'."
+      if (verbose) then
+          write (*,'(A)') "############################################################"
+          write (*,'(A)') "                       MAGNETIC FIELD"
+          write (*,'(A)') "############################################################"
+          write (*,*) "About to read VMEC wout file: '",trim(vmec_filename),"'."
+      end if
       call read_wout_file(vmec_filename, ierr, iopen)
       if (iopen /= 0) stop 'error opening wout file'
       if (ierr /= 0) stop 'error reading wout file'
-      write (*, *) "Successfully read VMEC data from '", trim(vmec_filename), "'."
+      if (verbose) then
+          write (*,*) "Successfully read VMEC data from '",trim(vmec_filename),"'."
+      end if
 
       nfp = nfp_vmec
       lasym = lasym_vmec
@@ -110,10 +116,12 @@ contains
       mpol = mpol_vmec
       ntor = ntor_vmec
 
-      write (*, *) " "
-      write (*, *) "  Characteristics of the magnetic field:"
-      write (*, '(A44, I1)') "      Number of field periods (nfp):"//repeat(' ', 50), nfp
-      write (*, '(A44, L1)') "      Stellarator-asymmetric? (lasym):"//repeat(' ', 50), lasym
+      if (verbose) then
+          write (*,*) " "
+          write (*,*) "  Characteristics of the magnetic field:"
+          write (*,'(A51, I1)') "      Number of field periods of the machine (nfp):"//REPEAT(' ',50),nfp
+          write (*,'(A51, L1)') "      Stellarator-asymmetric? (lasym):"//REPEAT(' ',50),lasym
+      end if
 
       if (.not. allocated(rmnc)) then
          allocate (xm(mnmax)); xm = xm_vmec
@@ -154,11 +162,15 @@ contains
 
    end subroutine read_vmec_equilibrium
 
-   subroutine get_nominal_vmec_zeta_grid(nzgrid, zeta_center, number_of_field_periods_stella, &
-                                         number_of_field_periods_device, zeta)
+   subroutine get_nominal_vmec_zeta_grid (new_zeta_min, stellarator_symmetric_BC, nzgrid, zeta_center, &
+                                         number_of_field_periods_stella, number_of_field_periods_device, zeta)
 
       implicit none
 
+      ! stellarator_symmetric_BC = true if twist_shift_option = stellarator
+      logical, intent (in) :: stellarator_symmetric_BC
+      ! new_zeta_min is the new minimum value of the parallel coordinate if dkx_over_dky != -1 selected
+      real, intent (in) :: new_zeta_min
       ! 2*nzgrid+1 is the number of zeta grid points for the nominal zeta grid
       integer, intent(in) :: nzgrid
       ! The zeta domain is centered at zeta_center. Setting zeta_center = 2*pi*N/nfp for any integer N should
@@ -166,6 +178,9 @@ contains
       real, intent(in) :: zeta_center
       ! number_of_field_periods_device is the number of field periods sampled by stella
       real, intent(in out) :: number_of_field_periods_stella
+      ! number_of_field_periods_stella_new is the new number of field periods that the code should compute if
+      ! dkx_over_dky != -1
+      real :: number_of_field_periods_stella_new
       ! number_of_field_periods_device is the number of field periods for the device
       real, intent(out) :: number_of_field_periods_device
       ! On exit, zeta holds the nominal grid points in the toroidal angle zeta
@@ -177,7 +192,15 @@ contains
       number_of_field_periods_device = nfp
 
       if (number_of_field_periods_stella < 0.0) &
-         number_of_field_periods_stella = number_of_field_periods_device
+          number_of_field_periods_stella = number_of_field_periods_device
+
+      if (stellarator_symmetric_BC) then 
+          number_of_field_periods_stella_new = (new_zeta_min - zeta_center)*nfp / (pi)
+          write(*,*) 'Number of field periods sampled by stella has changed from', number_of_field_periods_stella, &
+                          'to', number_of_field_periods_stella_new
+          write(*,*) 
+          number_of_field_periods_stella = number_of_field_periods_stella_new
+      end if
 
       zeta = [(zeta_center + (pi * j * number_of_field_periods_stella) / (nfp * nzgrid), j=-nzgrid, nzgrid)]
 
@@ -1711,5 +1734,35 @@ contains
       end do
 
    end function fzero_residual
+
+   subroutine desired_zmin(nalpha, nzgrid, zeta, twist_shift_factor_full, dkx_over_dky, new_zeta_min)
+
+      integer, intent(in) :: nzgrid, nalpha
+      integer :: location 
+      real, intent(in) :: dkx_over_dky
+      real, intent(in), dimension(nalpha,-nzgrid:nzgrid) :: zeta
+      real, intent(in), dimension(nalpha,-nzgrid:nzgrid) :: twist_shift_factor_full
+        
+      real, intent(out) :: new_zeta_min
+
+      real :: delt = 0.08
+      integer :: iz
+      ! Just defined for nalpha = 1. Just the positive values since the factor is antisymmetric
+      do iz = -nzgrid, nzgrid
+          if ( (abs(twist_shift_factor_full(1,iz)) + delt > dkx_over_dky) .and. (abs(twist_shift_factor_full(1,iz)) - delt < dkx_over_dky) ) then
+              location = iz  
+          end if 
+      end do
+      if (location == nzgrid) then
+              write(*,*)
+              write(*,*) 'No point in the FT fullfils your requirements'
+              write(*,*) 'Simulating nfield_periods indicated in the iput file'
+              write(*,*)
+      end if
+      ! The last computed iz will be the closest value to the initial grid that fullfills the conditions required.
+      new_zeta_min =  zeta(1,location)  
+
+   end subroutine 
+
 
 end module vmec_to_stella_geometry_interface_mod

--- a/zgrid.f90
+++ b/zgrid.f90
@@ -12,6 +12,7 @@ module zgrid
    public :: get_arc_length_grid
    public :: shat_zero
    public :: grad_x_grad_y_zero
+   public :: dkx_over_dky
    public :: boundary_option_switch
    public :: boundary_option_zero
    public :: boundary_option_self_periodic
@@ -23,7 +24,7 @@ module zgrid
    integer :: nzed, nzgrid, nztot, nz2pi
    integer :: nperiod, ntubes
    logical :: zed_equal_arc
-   real :: shat_zero, grad_x_grad_y_zero
+   real :: shat_zero, grad_x_grad_y_zero, dkx_over_dky
    real, dimension(:), allocatable :: zed, delzed
 
    integer :: boundary_option_switch
@@ -89,7 +90,7 @@ contains
 
       namelist /zgrid_parameters/ nzed, nperiod, ntubes, &
          shat_zero, boundary_option, zed_equal_arc, &
-         boundary_option, zed_equal_arc, grad_x_grad_y_zero
+         boundary_option, zed_equal_arc, grad_x_grad_y_zero, dkx_over_dky
 
       nzed = 24
       nperiod = 1
@@ -105,6 +106,10 @@ contains
       ! set the minimum nabla x . nabla value at the end of the FT which we assume
       ! periodic BC instead of the stellarator symmetric ones
       grad_x_grad_y_zero = 1.e-5
+      ! set the ratio between dkx and dky, assuming jtwist = 1.
+      ! if it is < 0, the code will just use the nfield_periods in the input file
+      dkx_over_dky = -1
+
 
       in_file = input_unit_exist("zgrid_parameters", exist)
       if (exist) read (unit=in_file, nml=zgrid_parameters)
@@ -140,6 +145,7 @@ contains
       call broadcast(shat_zero)
       call broadcast(boundary_option_switch)
       call broadcast(grad_x_grad_y_zero)
+      call broadcast (dkx_over_dky)
 
    end subroutine broadcast_parameters
 


### PR DESCRIPTION
i) Bug in the stellarator symmetric twist and shift BC factor fixed.

ii) Now it is possible to choose automatically the length of the flux tube depending on the desired $dkx/dky$ if using stellarator symmetric twist and shift BC. This is done via the new input variable 'dkx_over_dky'.