### PR TITLE
Use fields extended vector rather than passing phi directly as rhs in…

### DIFF
--- a/parallel_streaming.f90
+++ b/parallel_streaming.f90
@@ -1068,7 +1068,7 @@ contains
                   end if
 
                   call lu_back_substitution(response_matrix(iky)%eigen(ie)%zloc, &
-                                            response_matrix(iky)%eigen(ie)%idx, phi(iky, ikx, :nzgrid - 1, it))
+                                            response_matrix(iky)%eigen(ie)%idx, fields_ext)
                   ! Get fields on extended grid -> phi, apar, bpar on regular grids
                   ifield = 0
                   if (fphi > epsilon(0.)) then


### PR DESCRIPTION
… LU solve

Avoids out of bounds access in EM runs and also ensures that the result is actually used. Previously I think this would end up restoring the field values from before the back substitution (as it copies into fields_ext and then copies out again without changing fields_ext).