### PR TITLE
Bugfix/reset dt consistently new

### DIFF
--- a/response_matrix.fpp
+++ b/response_matrix.fpp
@@ -550,7 +550,7 @@ contains
                   ! of the homogeneous GKE at this zed index
                   fac0 = fac * ((1.+zed_upwind) * gradpar(iz) &
                                 + (1.-zed_upwind) * gradpar(iz - 1)) &
-                         * (maxwell_mu(ia, iz, imu, is) +  maxwell_mu(ia, iz - 1, imu, is))
+                         * (maxwell_mu(ia, iz, imu, is) + maxwell_mu(ia, iz - 1, imu, is))
                   ! fac1 is the factor multiplying delphi on the RHS
                   ! of the homogeneous GKE at the zed index to the right of
                   ! this one
@@ -574,7 +574,7 @@ contains
                   ! this one
                   fac1 = fac * ((1.+zed_upwind) * gradpar(iz + 1) &
                                 + (1.-zed_upwind) * gradpar(iz)) &
-                         * (maxwell_mu(ia, iz + 1, imu, is) +  maxwell_mu(ia, iz, imu, is))
+                         * (maxwell_mu(ia, iz + 1, imu, is) + maxwell_mu(ia, iz, imu, is))
                end if
                gext(idx, ivmu) = fac0
                if (idx < nz_ext) gext(idx + 1, ivmu) = -fac1
@@ -600,7 +600,7 @@ contains
                   if (iz > -nzgrid) then
                      fac1 = fac * ((1.+zed_upwind) * gradpar(iz - 1) &
                                    + (1.-zed_upwind) * gradpar(iz)) &
-                            * (maxwell_mu(ia, iz - 1, imu, is) +  maxwell_mu(ia, iz, imu, is))
+                            * (maxwell_mu(ia, iz - 1, imu, is) + maxwell_mu(ia, iz, imu, is))
                   else
                      fac1 = fac * ((1.+zed_upwind) * gradpar(nzgrid - 1) &
                                    + (1.-zed_upwind) * gradpar(iz)) &

--- a/time_advance.f90
+++ b/time_advance.f90
@@ -1143,7 +1143,7 @@ contains
    end subroutine advance_explicit_rk2
 
    !> strong stability-preserving RK3
-   subroutine advance_explicit_rk3(g)
+   subroutine advance_explicit_rk3(g, restart_time_step)
 
       use dist_fn_arrays, only: g0, g1, g2
       use zgrid, only: nzgrid
@@ -1194,7 +1194,7 @@ contains
    end subroutine advance_explicit_rk3
 
    !> standard RK4
-   subroutine advance_explicit_rk4(g)
+   subroutine advance_explicit_rk4(g, restart_time_step)
 
       use dist_fn_arrays, only: g0, g1, g2, g3
       use zgrid, only: nzgrid
@@ -1242,7 +1242,7 @@ contains
          end select
          if (restart_time_step) then
            !> if CFL condition is violated by nonlinear term
-           !> then must modify time step size and restart time step           
+           !> then must modify time step size and restart time step
             icnt = 1
          else
             icnt = icnt + 1

--- a/time_advance.f90
+++ b/time_advance.f90
@@ -1241,13 +1241,8 @@ contains
             g1 = g1 + g
          end select
          if (restart_time_step) then
-<<<<<<< HEAD
-           !> if CFL condition is violated by nonlinear term
-           !> then must modify time step size and restart time step
-=======
             !> if CFL condition is violated by nonlinear term
             !> then must modify time step size and restart time step
->>>>>>> 85b1b7eeeba5f939cd1380c4b1c2394b5c96e90e
             icnt = 1
          else
             icnt = icnt + 1


### PR DESCRIPTION
This is a fix for [#33]; I've tested and confirmed (by forcing restart_time_step to .true.) that if the timestep needs be reset, the changes to g and phi are discarded and the timestep is re-done (for both flip_flop = .false. and flip_flop = .true.)