### PR TITLE
Avoiding dividing by zero in fields.fpp

### DIFF
--- a/dissipation.f90
+++ b/dissipation.f90
@@ -6102,7 +6102,7 @@ bb_blcs(iv,imu,imu-1,ikxkyz,isb)= bb_blcs(iv,imu,imu-1,ikxkyz,isb) - code_dt*((-
 
          !get k2max at outboard midplane
          k2max = akx(ikx_max)**2 + aky(naky)**2
-         if (k2max.lt.epsilon(0.0)) k2max = 1.0
+         if (k2max < epsilon(0.0)) k2max = 1.0
 
          tfac = geo_surf%shat**2
          if (q_as_x) tfac = 1.0
@@ -6126,7 +6126,7 @@ bb_blcs(iv,imu,imu-1,ikxkyz,isb)= bb_blcs(iv,imu,imu-1,ikxkyz,isb) - code_dt*((-
          end do
       else
          k2max = maxval(kperp2)
-         if (k2max.lt.epsilon(0.0)) k2max = 1.0
+         if (k2max < epsilon(0.0)) k2max = 1.0
          ia = 1
          ! add in hyper-dissipation of form dg/dt = -D*(k/kmax)^4*g
          do ivmu = vmu_lo%llim_proc, vmu_lo%ulim_proc

--- a/fields.fpp
+++ b/fields.fpp
@@ -1226,6 +1226,7 @@ contains
 
       complex, dimension(:, :, -nzgrid:, :), intent(in out) :: phi
       logical, optional, intent(in) :: skip_fsa
+      real, dimension(:, :, :, :), allocatable :: gamtot_t
       integer :: ia, it, ikx
       complex :: tmp
       logical :: skip_fsa_local
@@ -1259,8 +1260,14 @@ contains
             call mb_get_phi(phi, has_elec, adia_elec)
          else
             ! divide <g> by sum_s (\Gamma_0s-1) Zs^2*e*ns/Ts to get phi
-            phi = phi / spread(gamtot, 4, ntubes)
-            if (any(gamtot(1, 1, :) < epsilon(0.))) phi(1, 1, :, :) = 0.0
+            allocate (gamtot_t(naky, nakx, -nzgrid:nzgrid, ntubes))
+            gamtot_t = spread(gamtot, 4, ntubes)
+            where (gamtot_t < epsilon(0.0))
+               phi = 0.0
+            elsewhere
+               phi = phi / gamtot_t
+            end where
+            deallocate (gamtot_t)
          end if
       else
          if (proc0) write (*, *) 'unknown dist option in get_fields. aborting'
@@ -1661,6 +1668,7 @@ contains
 
       integer :: ikx, iky, ivmu, iz, it, ia, is, imu
       complex :: tmp
+      real, dimension(:, :, :, :), allocatable :: gamtot_t
       complex, dimension(:, :, :, :), allocatable :: phi1
       complex, dimension(:, :, :), allocatable :: gyro_g
       complex, dimension(:, :), allocatable :: g0k, g1k, g1x
@@ -1702,9 +1710,14 @@ contains
          end do
 
          if (dist == 'gbar') then
-            !call get_phi (phi)
-            phi1 = phi1 / spread(gamtot, 4, ntubes)
-            phi1(1, 1, :, :) = 0.0
+            allocate (gamtot_t(naky, nakx, -nzgrid:nzgrid, ntubes))
+            gamtot_t = spread(gamtot, 4, ntubes)
+            where (gamtot_t < epsilon(0.0))
+               phi1 = 0.0
+            elsewhere
+               phi1 = phi1 / gamtot_t
+            end where
+            deallocate (gamtot_t)
          else if (dist == 'h') then
             if (proc0) write (*, *) 'dist option "h" not implemented in radial_correction. aborting'
             call mp_abort('dist option "h" in radial_correction. aborting')

--- a/sources.fpp
+++ b/sources.fpp
@@ -145,7 +145,7 @@ contains
          in_file = input_unit_exist("sources", dexist)
          if (dexist) read (unit=in_file, nml=sources)
 
-         if (tcorr_source_qn .lt. 0) tcorr_source_qn = tcorr_source
+         if (tcorr_source_qn < 0) tcorr_source_qn = tcorr_source
       end if
 
       ikxmax_source = min(ikxmax_source, ikx_max)
@@ -175,17 +175,17 @@ contains
 
       implicit none
 
-      if (tcorr_source .gt. 0.0) then
+      if (tcorr_source > 0.0) then
          exp_fac = exp(-code_dt / tcorr_source)
       else
          exp_fac = 0.0
-      endif
+      end if
 
-      if (tcorr_source_qn .gt. 0.0) then
+      if (tcorr_source_qn > 0.0) then
          exp_fac_qn = exp(-code_dt / tcorr_source_qn)
       else
          exp_fac_qn = 0.0
-      endif
+      end if
 
    end subroutine init_source_timeaverage
 


### PR DESCRIPTION
Avoids division by zero, which makes debugging with -ffpe-trap=invalid,overflow,zero a little easier.