### PR TITLE
Make sure time arrays are initialised

### DIFF
--- a/fields.fpp
+++ b/fields.fpp
@@ -40,7 +40,7 @@ module fields
 
    integer :: zm
 
-   real, dimension(2, 5) :: time_field_solve
+   real, dimension(2, 5) :: time_field_solve = 0.
 
    interface get_dchidy
       module procedure get_dchidy_4d

--- a/parallel_streaming.f90
+++ b/parallel_streaming.f90
@@ -32,7 +32,7 @@ module parallel_streaming
    real, dimension(:, :), allocatable :: stream_tri_c1, stream_tri_c2
    real, dimension(:, :), allocatable :: gradpar_c
 
-   real, dimension(2) :: time_parallel_streaming
+   real, dimension(2) :: time_parallel_streaming = 0.
 
 contains
 


### PR DESCRIPTION
Calls to `time_message` use the value of the passed time array to decide what to do, if we don't initialise the array then this behaviour is undefined.