### PR TITLE
CI: Setup python in docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,14 +20,16 @@ jobs:
                  libfftw3-dev
                  libnetcdf-dev
                  libnetcdff-dev
-                 python3
-                 python3-pip
                  rsync
 
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
     - name: Install FORD
       run: |
-        pip3 install --upgrade pip
-        pip3 install ford
+        python -m pip install --upgrade pip
+        pip install ford
         ford --version
     - name: Build documentation
       run: |


### PR DESCRIPTION
This should hopefully ensure pip fetches a more recent version of jinja2