### PR TITLE
Fix bug with restarted simulations with longer input files

### DIFF
--- a/tests/integrated/restart/end_half_run.in
+++ b/tests/integrated/restart/end_half_run.in
@@ -1,0 +1,148 @@
+! JET shot 92174
+
+&zgrid_parameters
+ nzed = 32
+ nperiod = 1
+ boundary_option="linked"
+/
+
+&geo_knobs
+ geo_option = 'miller'
+/
+
+&millergeo_parameters
+ nzed_local = 128
+ rhoc = 9.7427e-01 ! r/a
+ shat = 3.3594e+00
+ qinp = 5.0848e+00
+ rmaj = 3.1340e+00
+ rgeo = 3.1191e+00
+ shift = -3.4508e-01
+ kappa = 1.5504e+00
+ kapprim = 9.4963e-01
+ tri = 2.6253e-01
+ triprim = 7.3680e-01
+ betaprim = 0.58e-01
+
+ d2qdr2 = 0.0
+ d2psidr2 = 0.0
+ betadbprim = 0.0
+/
+
+&physics_flags
+ full_flux_surface = .false.
+ nonlinear = .true.
+/
+
+&parameters
+ zeff = 1.0
+ beta = 0.01
+ vnew_ref = 0.01
+ rhostar = 0.01
+/
+
+&vpamu_grids_parameters
+ nvgrid = 3 ! 64
+ nmu = 2 !32
+ vpa_max = 3.0
+/
+
+&time_advance_knobs
+ explicit_option="rk2"
+/
+
+&kt_grids_knobs
+ grid_option='box'
+/
+
+&kt_grids_box_parameters
+ ny = 2
+ nx = 2
+ y0 = 20.0
+ jtwist = 5
+/
+
+&init_g_knobs
+ chop_side = F
+ phiinit=   1.0e-2
+ restart_file = "restart.nc"
+ ginit_option= "many"
+ width0 = 1.0
+/
+
+&knobs
+ fphi =   1.0
+ fapar =  0.0
+ fbpar = 0.0
+ zed_upwind = 0.02
+ time_upwind = 0.02
+ vpa_upwind = 0.02
+ delt = 0.02
+ nstep = 500
+ mat_gen = .false.
+ delt_option = "check_restart"
+/
+
+&species_knobs
+ nspec= 2
+ species_option = 'stella'
+/
+
+&species_parameters_1
+ z=   1.0
+ mass=   2.0
+ dens=   1.0
+ temp=   1.0
+ tprim = 11.150280766906535 ! by minor radius, multiply by 3.2 to get R/L_T
+ fprim = 10.076043143968478
+ type='ion'
+/
+
+&species_parameters_2
+ z=   -1.0
+ mass=   0.00054
+ dens=   1.0
+ temp=   0.5570183368724737
+ tprim=  42.296287675811435
+ fprim=  10.076043143968478
+ type='electron'
+/
+
+&stella_diagnostics_knobs
+ nwrite = 50
+ nsave = 1000
+ save_for_restart = .true.
+ write_omega = .true.
+ write_phi_vs_time = .true.
+ write_gvmus = .true.
+ write_gzvs = .true.
+ write_kspectra = .true.
+ write_radial_fluxes = .true.
+ write_radial_moments = .true.
+ write_fluxes_kxkyz = .true.
+/
+
+&reinit_knobs
+ delt_adj = 2.0
+ delt_minimum = 1.e-4
+/
+
+&layouts_knobs
+ xyzs_layout = 'yxzs'
+ vms_layout = 'vms'
+/
+
+&neoclassical_input
+ include_neoclassical_terms = .false.
+ neo_option = 'sfincs'
+/
+
+&sfincs_input
+ nproc_sfincs = 2
+ nxi = 16
+ nx = 5
+/
+
+&dissipation
+ hyper_dissipation = .true.
+/

--- a/tests/integrated/restart/full_run.in
+++ b/tests/integrated/restart/full_run.in
@@ -1,0 +1,147 @@
+! JET shot 92174
+
+&zgrid_parameters
+ nzed = 32
+ nperiod = 1
+ boundary_option="linked"
+/
+
+&geo_knobs
+ geo_option = 'miller'
+/
+
+&millergeo_parameters
+ nzed_local = 128
+ rhoc = 9.7427e-01 ! r/a
+ shat = 3.3594e+00
+ qinp = 5.0848e+00
+ rmaj = 3.1340e+00
+ rgeo = 3.1191e+00
+ shift = -3.4508e-01
+ kappa = 1.5504e+00
+ kapprim = 9.4963e-01
+ tri = 2.6253e-01
+ triprim = 7.3680e-01
+ betaprim = 0.58e-01
+
+ d2qdr2 = 0.0
+ d2psidr2 = 0.0
+ betadbprim = 0.0
+/
+
+&physics_flags
+ full_flux_surface = .false.
+ nonlinear = .true.
+/
+
+&parameters
+ zeff = 1.0
+ beta = 0.01
+ vnew_ref = 0.01
+ rhostar = 0.01
+/
+
+&vpamu_grids_parameters
+ nvgrid = 3 ! 64
+ nmu = 2 !32
+ vpa_max = 3.0
+/
+
+&time_advance_knobs
+ explicit_option="rk2"
+/
+
+&kt_grids_knobs
+ grid_option='box'
+/
+
+&kt_grids_box_parameters
+ ny = 2
+ nx = 2
+ y0 = 20.0
+ jtwist = 5
+/
+
+&init_g_knobs
+ chop_side = F
+ phiinit=   1.0e-2
+ restart_file = "nc/example.nc"
+ ginit_option= "noise"
+ width0 = 1.0
+/
+
+&knobs
+ fphi =   1.0
+ fapar =  0.0
+ fbpar = 0.0
+ zed_upwind = 0.02
+ time_upwind = 0.02
+ vpa_upwind = 0.02
+ delt = 0.02
+ nstep = 500
+ mat_gen = .false.
+/
+
+&species_knobs
+ nspec= 2
+ species_option = 'stella'
+/
+
+&species_parameters_1
+ z=   1.0
+ mass=   2.0
+ dens=   1.0
+ temp=   1.0
+ tprim = 11.150280766906535 ! by minor radius, multiply by 3.2 to get R/L_T
+ fprim = 10.076043143968478
+ type='ion'
+/
+
+&species_parameters_2
+ z=   -1.0
+ mass=   0.00054
+ dens=   1.0
+ temp=   0.5570183368724737
+ tprim=  42.296287675811435
+ fprim=  10.076043143968478
+ type='electron'
+/
+
+&stella_diagnostics_knobs
+ nwrite = 50
+ nsave = 1000
+ save_for_restart = .false.
+ write_omega = .true.
+ write_phi_vs_time = .true.
+ write_gvmus = .true.
+ write_gzvs = .true.
+ write_kspectra = .true.
+ write_radial_fluxes = .true.
+ write_radial_moments = .true.
+ write_fluxes_kxkyz = .true.
+/
+
+&reinit_knobs
+ delt_adj = 2.0
+ delt_minimum = 1.e-4
+/
+
+&layouts_knobs
+ xyzs_layout = 'yxzs'
+ vms_layout = 'vms'
+/
+
+&neoclassical_input
+ include_neoclassical_terms = .false.
+ neo_option = 'sfincs'
+/
+
+&sfincs_input
+ nproc_sfincs = 2
+ nxi = 16
+ nx = 5
+/
+
+&dissipation
+ hyper_dissipation = .true.
+/

--- a/tests/integrated/restart/start_half_run.in
+++ b/tests/integrated/restart/start_half_run.in
@@ -1,0 +1,147 @@
+! JET shot 92174
+
+&zgrid_parameters
+ nzed = 32
+ nperiod = 1
+ boundary_option="linked"
+/
+
+&geo_knobs
+ geo_option = 'miller'
+/
+
+&millergeo_parameters
+ nzed_local = 128
+ rhoc = 9.7427e-01 ! r/a
+ shat = 3.3594e+00
+ qinp = 5.0848e+00
+ rmaj = 3.1340e+00
+ rgeo = 3.1191e+00
+ shift = -3.4508e-01
+ kappa = 1.5504e+00
+ kapprim = 9.4963e-01
+ tri = 2.6253e-01
+ triprim = 7.3680e-01
+ betaprim = 0.58e-01
+
+ d2qdr2 = 0.0
+ d2psidr2 = 0.0
+ betadbprim = 0.0
+/
+
+&physics_flags
+ full_flux_surface = .false.
+ nonlinear = .true.
+/
+
+&parameters
+ zeff = 1.0
+ beta = 0.01
+ vnew_ref = 0.01
+ rhostar = 0.01
+/
+
+&vpamu_grids_parameters
+ nvgrid = 3 ! 64
+ nmu = 2 !32
+ vpa_max = 3.0
+/
+
+&time_advance_knobs
+ explicit_option="rk2"
+/
+
+&kt_grids_knobs
+ grid_option='box'
+/
+
+&kt_grids_box_parameters
+ ny = 2
+ nx = 2
+ y0 = 20.0
+ jtwist = 5
+/
+
+&init_g_knobs
+ chop_side = F
+ phiinit=   1.0e-2
+ restart_file = "restart.nc"
+ ginit_option= "noise"
+ width0 = 1.0
+/
+
+&knobs
+ fphi =   1.0
+ fapar =  0.0
+ fbpar = 0.0
+ zed_upwind = 0.02
+ time_upwind = 0.02
+ vpa_upwind = 0.02
+ delt = 0.02
+ nstep = 250
+ mat_gen = .false.
+/
+
+&species_knobs
+ nspec= 2
+ species_option = 'stella'
+/
+
+&species_parameters_1
+ z=   1.0
+ mass=   2.0
+ dens=   1.0
+ temp=   1.0
+ tprim = 11.150280766906535 ! by minor radius, multiply by 3.2 to get R/L_T
+ fprim = 10.076043143968478
+ type='ion'
+/
+
+&species_parameters_2
+ z=   -1.0
+ mass=   0.00054
+ dens=   1.0
+ temp=   0.5570183368724737
+ tprim=  42.296287675811435
+ fprim=  10.076043143968478
+ type='electron'
+/
+
+&stella_diagnostics_knobs
+ nwrite = 50
+ nsave = 1000
+ save_for_restart = .true.
+ write_omega = .true.
+ write_phi_vs_time = .true.
+ write_gvmus = .true.
+ write_gzvs = .true.
+ write_kspectra = .true.
+ write_radial_fluxes = .true.
+ write_radial_moments = .true.
+ write_fluxes_kxkyz = .true.
+/
+
+&reinit_knobs
+ delt_adj = 2.0
+ delt_minimum = 1.e-4
+/
+
+&layouts_knobs
+ xyzs_layout = 'yxzs'
+ vms_layout = 'vms'
+/
+
+&neoclassical_input
+ include_neoclassical_terms = .false.
+ neo_option = 'sfincs'
+/
+
+&sfincs_input
+ nproc_sfincs = 2
+ nxi = 16
+ nx = 5
+/
+
+&dissipation
+ hyper_dissipation = .true.
+/

--- a/tests/integrated/restart/test_restarting.py
+++ b/tests/integrated/restart/test_restarting.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import os
+import pathlib
+import shutil
+import subprocess
+import xarray as xr
+
+
+def get_test_directory() -> pathlib.Path:
+    """Get the directory of this test file"""
+    return pathlib.Path(__file__).parent
+
+
+def get_stella_path() -> pathlib.Path:
+    """Returns the absolute path to the stella executable
+
+    Can be controlled by setting the STELLA_EXE_PATH environment variable
+    """
+    default_path = get_test_directory() / "../../../stella"
+    stella_path = pathlib.Path(os.environ.get("STELLA_EXE_PATH", default_path))
+    return stella_path.absolute()
+
+
+def run_stella(stella_path: str, input_filename: str) -> int:
+    """Run stella with a given input file"""
+    subprocess.run([stella_path, input_filename], check=True)
+
+
+def copy_input_file(input_filename: str, destination):
+    """Copy input_filename to destination directory"""
+    shutil.copyfile(get_test_directory() / input_filename, destination / input_filename)
+
+
+def convert_byte_array(array):
+    return "\n".join((str(line, encoding="utf-8").strip() for line in array.data))
+
+
+def compare_two_output_files(file1, file2, tolerance=1e-6):
+    """Compares all the variables in file1 and file2 using `numpy.allclose`"""
+
+    VARIABLES_TO_SKIP = [
+        "input_file",
+        "code_info",
+    ]
+
+    with xr.open_dataset(file1) as df, xr.open_dataset(file2) as golden:
+        assert set(df.keys()) == set(golden.keys())
+
+        for key in golden:
+            if key in VARIABLES_TO_SKIP:
+                continue
+
+            if golden[key].shape == ():
+                continue
+            if golden[key].dtype.kind == "S":
+                golden_str = convert_byte_array(golden[key])
+                df_str = convert_byte_array(df[key])
+                assert df_str == golden_str, key
+            else:
+                assert np.allclose(df[key], golden[key], equal_nan=True), key
+
+
+def test_restart(tmp_path):
+    full_input_file = "full_run.in"
+    start_half_input_file = "start_half_run.in"
+    end_half_input_file = "end_half_run.in"
+
+    for input_file in [full_input_file, start_half_input_file, end_half_input_file]:
+        copy_input_file(input_file, tmp_path)
+
+    os.chdir(tmp_path)
+
+    run_stella(get_stella_path(), full_input_file)
+    run_stella(get_stella_path(), start_half_input_file)
+
+    shutil.copy(tmp_path / "start_half_run.out.nc", tmp_path / "end_half_run.out.nc")
+
+    run_stella(get_stella_path(), end_half_input_file)
+
+    compare_two_output_files("full_run.out.nc", "end_half_run.out.nc")


### PR DESCRIPTION
Fixes #85

Previously, if a simulation was restarted and the new input file was
longer than the one in the netCDF file, we would hard error.
Now, the "number of lines" dimension is unlimited, so longer input
files can always be written. If the new input file is shorter, we
blank out the variable first.

Also adds a test for restarting simulations -- run a full length simulation, then two half-length ones. The final half-length output file should be identical to the full length one.

@rd1042 I reproduced your bug and this seems to fix it, but please could you double check it for your case?