### PR TITLE
Changed netcdf package from scipy to netCDF4 to allow for compatibili…

### DIFF
--- a/post_processing/stella_data.py
+++ b/post_processing/stella_data.py
@@ -3,28 +3,31 @@
 ## Description: import variables from stella netcdf file
 
 from scipy.io import netcdf
+from netCDF4 import Dataset
+
 import numpy as np
 
 ####### Import variables from netcdf file #########
 #infile = input("Path to netcdf file: ")
-input_directory = '/Users/barnesm/Documents/stella_data/bistability/'
-file_prefix = 'jet68448_nogexb'
+input_directory = '/your/run/dir/'
+file_prefix = 'your-simulation-name'
 infile = input_directory + file_prefix + '.out.nc'
 #infile = '../stella.out.nc'
 #print()
 #outdir = input("Path for output: ")
 outdir = input_directory
-ncfile = netcdf.netcdf_file(infile,'r')
 
+#ncfile = netcdf.netcdf_file(infile,'r')
+ncfile = Dataset(infile, 'r',format='NETCDF4')
 #print()
 print('reading data from netcdf file...')
 print()
 
 # get kx and ky grids
 kx_stella = np.copy(ncfile.variables['kx'][:])
-nakx = ncfile.dimensions['kx']
+nakx = ncfile.dimensions['kx'].size
 ky = np.copy(ncfile.variables['ky'][:])
-naky = ncfile.dimensions['ky']
+naky = ncfile.dimensions['ky'].size
 
 # this is the index of the first negative value of kx
 # note stella orders kx as (0, dkx, ..., kx_max, -kx_max, -kx_max+dkx, ..., -dkx)


### PR DESCRIPTION
…ty with current netcdf output

Executing

$ python3 kspectra_plots.py

On my favourite stella *.out.nc file leads to the following error

Traceback (most recent call last):
File "kspectra_plots.py", line 3, in
from stella_data import time, ntime, outdir, nakx, naky, kx, ky
TypeError: Error: *.out.nc is not a valid NetCDF 3 file

This is fixed with this pull request

