### PR TITLE
Bugfix/avail cpu time

### DIFF
--- a/post_processing/stella_data.py
+++ b/post_processing/stella_data.py
@@ -3,28 +3,31 @@
 ## Description: import variables from stella netcdf file
 
 from scipy.io import netcdf
+from netCDF4 import Dataset
+
 import numpy as np
 
 ####### Import variables from netcdf file #########
 #infile = input("Path to netcdf file: ")
-input_directory = '/Users/barnesm/Documents/stella_data/bistability/'
-file_prefix = 'jet68448_nogexb'
+input_directory = '/your/run/dir/'
+file_prefix = 'your-simulation-name'
 infile = input_directory + file_prefix + '.out.nc'
 #infile = '../stella.out.nc'
 #print()
 #outdir = input("Path for output: ")
 outdir = input_directory
-ncfile = netcdf.netcdf_file(infile,'r')
 
+#ncfile = netcdf.netcdf_file(infile,'r')
+ncfile = Dataset(infile, 'r',format='NETCDF4')
 #print()
 print('reading data from netcdf file...')
 print()
 
 # get kx and ky grids
 kx_stella = np.copy(ncfile.variables['kx'][:])
-nakx = ncfile.dimensions['kx']
+nakx = ncfile.dimensions['kx'].size
 ky = np.copy(ncfile.variables['ky'][:])
-naky = ncfile.dimensions['ky']
+naky = ncfile.dimensions['ky'].size
 
 # this is the index of the first negative value of kx
 # note stella orders kx as (0, dkx, ..., kx_max, -kx_max, -kx_max+dkx, ..., -dkx)

--- a/post_processing/stella_data.py
+++ b/post_processing/stella_data.py
@@ -3,31 +3,28 @@
 ## Description: import variables from stella netcdf file
 
 from scipy.io import netcdf
-from netCDF4 import Dataset
-
 import numpy as np
 
 ####### Import variables from netcdf file #########
 #infile = input("Path to netcdf file: ")
-input_directory = '/your/run/dir/'
-file_prefix = 'your-simulation-name'
+input_directory = '/Users/barnesm/Documents/stella_data/bistability/'
+file_prefix = 'jet68448_nogexb'
 infile = input_directory + file_prefix + '.out.nc'
 #infile = '../stella.out.nc'
 #print()
 #outdir = input("Path for output: ")
 outdir = input_directory
+ncfile = netcdf.netcdf_file(infile,'r')
 
-#ncfile = netcdf.netcdf_file(infile,'r')
-ncfile = Dataset(infile, 'r',format='NETCDF4')
 #print()
 print('reading data from netcdf file...')
 print()
 
 # get kx and ky grids
 kx_stella = np.copy(ncfile.variables['kx'][:])
-nakx = ncfile.dimensions['kx'].size
+nakx = ncfile.dimensions['kx']
 ky = np.copy(ncfile.variables['ky'][:])
-naky = ncfile.dimensions['ky'].size
+naky = ncfile.dimensions['ky']
 
 # this is the index of the first negative value of kx
 # note stella orders kx as (0, dkx, ..., kx_max, -kx_max, -kx_max+dkx, ..., -dkx)

--- a/stella.f90
+++ b/stella.f90
@@ -40,8 +40,10 @@ program stella
    istep = istep0 + 1
    do while ((code_time <= tend .AND. tend > 0) .OR. (istep <= nstep .AND. nstep > 0))
       if (debug) write (*, *) 'istep = ', istep
-      if (mod(istep, 10) == 0) call checkstop(stop_stella)
-      if (mod(istep, 10) == 0) call checktime(avail_cpu_time, stop_stella)
+      if (mod(istep, 10) == 0) then
+         call checkstop(stop_stella)
+         call checktime(avail_cpu_time, stop_stella)
+      end if
       if (stop_stella) exit
       call advance_stella(istep)
       call update_time

--- a/stella.f90
+++ b/stella.f90
@@ -2,7 +2,9 @@ program stella
 
    use redistribute, only: scatter
    use job_manage, only: time_message, checkstop, job_fork
+   use job_manage, only: checktime
    use run_parameters, only: nstep, tend, fphi, fapar
+   use run_parameters, only: avail_cpu_time
    use stella_time, only: update_time, code_time, code_dt
    use dist_redistribute, only: kxkyz2vmu
    use time_advance, only: advance_stella
@@ -39,6 +41,7 @@ program stella
    do while ((code_time <= tend .AND. tend > 0) .OR. (istep <= nstep .AND. nstep > 0))
       if (debug) write (*, *) 'istep = ', istep
       if (mod(istep, 10) == 0) call checkstop(stop_stella)
+      if (mod(istep, 10) == 0) call checktime(avail_cpu_time, stop_stella)
       if (stop_stella) exit
       call advance_stella(istep)
       call update_time


### PR DESCRIPTION
The available_CPU_time flag should cause a Stella to exit 5 minutes before is reached. This function is not currently supported in the main stella.f90 program. Restoring this function is potentially important for users carrying out large simulations where it is expected that the simulation will require multiple restarts to reach saturation.

Thanks to @DenSto for suggestions.