### PR TITLE
Adds zed_scalefac to the output netcdf file. 

### DIFF
--- a/stella_io.fpp
+++ b/stella_io.fpp
@@ -587,7 +587,7 @@ contains
       use neasyf, only: neasyf_write
       use stella_geometry, only: bmag, gradpar, gbdrift, gbdrift0, &
                                  cvdrift, cvdrift0, gds2, gds21, gds22, grho, jacob, &
-                                 drhodpsi, djacdrho, b_dot_grad_z
+                                 drhodpsi, djacdrho, b_dot_grad_z, zed_scalefac
       use stella_geometry, only: geo_surf
       use physics_parameters, only: beta
       use dist_fn_arrays, only: kperp2
@@ -617,6 +617,7 @@ contains
       call neasyf_write(file_id, "grho", grho, dim_names=flux_surface_dim)
       call neasyf_write(file_id, "jacob", jacob, dim_names=flux_surface_dim)
       call neasyf_write(file_id, "djacdrho", djacdrho, dim_names=flux_surface_dim)
+      call neasyf_write(file_id, "zed_scalefac", zed_scalefac, long_name="Factor to divide zed with to get zeta.")
       call neasyf_write(file_id, "beta", beta, &
                         long_name="Reference beta", units="2.mu0.nref.Tref/B_a**2")
       call neasyf_write(file_id, "q", geo_surf%qinp, &


### PR DESCRIPTION
zed_scalefac lets us calculate zeta (as defined in the stella.geometry file) from zed, allowing geometry files to be fully reconstructed from the stella netcdf output. Zeta is useful when we want to use a geometric quantity (such as gbdrift) from a different geometry file or stella simulation, as it lets us potentially interpolate to the zeta grid of the new simulation.
Being able to do this construction from the output netcdf file is more precise than using the plaintext .geometry file, as the plaintext .geometry file only saves these quantities with a few digits precision.