### PR TITLE
Auto-check whether pyrokinetics can load a stella output.

### DIFF
--- a/.github/workflows/check_pyrokinetics.yml
+++ b/.github/workflows/check_pyrokinetics.yml
@@ -51,7 +51,7 @@ jobs:
           sudo apt install -y netcdf-bin python3 python3-pip openmpi-bin libopenmpi-dev
           pip3 install --upgrade pip
           pip3 install --user -r AUTOMATIC_TESTS/requirements.txt
-          pip3 install --user -r EXTERNALS/pyrokinetics/.
+          pip3 install EXTERNALS/pyrokinetics/.
           sed -i 's/nproc = 16/nproc = 1/g' AUTOMATIC_TESTS/config.ini
           
       # Perform pyrokinetics tests

--- a/.github/workflows/check_pyrokinetics.yml
+++ b/.github/workflows/check_pyrokinetics.yml
@@ -1,0 +1,60 @@
+# Run these tests automatically on Github on every push and pull request.
+name: Check Pyrokinetics
+on: [push, pull_request]
+
+# We always run in a bash shell
+defaults:
+  run:
+    shell: bash
+
+# First build stella, and then perform pyrokinetics tests
+jobs:
+
+#-----------------------------------------------------------------------
+#                              Quick build                              
+#-----------------------------------------------------------------------
+
+  # Build stella to perform pyrokinetics tests
+  pyrokinetics-tests: 
+    name: Build stella quickly
+    runs-on: ubuntu-22.04
+    env:
+      OMPI_MCA_rmaps_base_oversubscribe: yes
+      MPIRUN: mpiexec -np
+      STELLA_SYSTEM: gnu_ubuntu
+
+    steps:
+
+      # Check-out repository under $GITHUB_WORKSPACE
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # Install dependencies
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y gfortran make libfftw3-dev libnetcdf-dev libnetcdff-dev 
+          sudo apt install -y netcdf-bin python3 python3-pip openmpi-bin libopenmpi-dev
+
+      # Build stella executable
+      - name: Build stella
+        run: |
+          git submodule update --init --recursive
+          make -j 12
+          chmod +x stella
+          
+      # Install dependencies
+      - name: Install dependencies and python virtual environment
+        run: |
+          sudo apt update
+          sudo apt install -y gfortran make libfftw3-dev libnetcdf-dev libnetcdff-dev 
+          sudo apt install -y netcdf-bin python3 python3-pip openmpi-bin libopenmpi-dev
+          pip3 install --user -r AUTOMATIC_TESTS/requirements.txt
+          sed -i 's/nproc = 16/nproc = 1/g' AUTOMATIC_TESTS/config.ini
+          
+      # Perform pyrokinetics tests
+      - name: Pyrokinetics tests
+        run: make pyrokinetics-tests
+
+
+

--- a/.github/workflows/check_pyrokinetics.yml
+++ b/.github/workflows/check_pyrokinetics.yml
@@ -50,7 +50,7 @@ jobs:
           sudo apt install -y gfortran make libfftw3-dev libnetcdf-dev libnetcdff-dev 
           sudo apt install -y netcdf-bin python3 python3-pip openmpi-bin libopenmpi-dev
           pip3 install --user -r AUTOMATIC_TESTS/requirements.txt
-          pip3 install --user -r EXTERNALS/pyrokinetics/.
+          pip install EXTERNALS/pyrokinetics/.
           sed -i 's/nproc = 16/nproc = 1/g' AUTOMATIC_TESTS/config.ini
           
       # Perform pyrokinetics tests

--- a/.github/workflows/check_pyrokinetics.yml
+++ b/.github/workflows/check_pyrokinetics.yml
@@ -16,7 +16,7 @@ jobs:
 
   # Build stella to perform pyrokinetics tests
   pyrokinetics-tests: 
-    name: Build stella quickly
+    name: Check Pyrokinetics
     runs-on: ubuntu-22.04
     env:
       OMPI_MCA_rmaps_base_oversubscribe: yes
@@ -50,6 +50,7 @@ jobs:
           sudo apt install -y gfortran make libfftw3-dev libnetcdf-dev libnetcdff-dev 
           sudo apt install -y netcdf-bin python3 python3-pip openmpi-bin libopenmpi-dev
           pip3 install --user -r AUTOMATIC_TESTS/requirements.txt
+          pip3 install EXTERNALS/pyrokinetics/.
           sed -i 's/nproc = 16/nproc = 1/g' AUTOMATIC_TESTS/config.ini
           
       # Perform pyrokinetics tests

--- a/.github/workflows/check_pyrokinetics.yml
+++ b/.github/workflows/check_pyrokinetics.yml
@@ -49,8 +49,9 @@ jobs:
           sudo apt update
           sudo apt install -y gfortran make libfftw3-dev libnetcdf-dev libnetcdff-dev 
           sudo apt install -y netcdf-bin python3 python3-pip openmpi-bin libopenmpi-dev
+          pip3 install --upgrade pip
           pip3 install --user -r AUTOMATIC_TESTS/requirements.txt
-          pip install EXTERNALS/pyrokinetics/.
+          pip3 install --user -r EXTERNALS/pyrokinetics/.
           sed -i 's/nproc = 16/nproc = 1/g' AUTOMATIC_TESTS/config.ini
           
       # Perform pyrokinetics tests

--- a/.github/workflows/check_pyrokinetics.yml
+++ b/.github/workflows/check_pyrokinetics.yml
@@ -50,8 +50,7 @@ jobs:
           sudo apt install -y gfortran make libfftw3-dev libnetcdf-dev libnetcdff-dev 
           sudo apt install -y netcdf-bin python3 python3-pip openmpi-bin libopenmpi-dev
           pip3 install --user -r AUTOMATIC_TESTS/requirements.txt
-          source AUTOMATIC_TESTS/venv/bin/activate
-          pip3 install EXTERNALS/pyrokinetics/.
+          pip3 install --user -r EXTERNALS/pyrokinetics/.
           sed -i 's/nproc = 16/nproc = 1/g' AUTOMATIC_TESTS/config.ini
           
       # Perform pyrokinetics tests

--- a/.github/workflows/check_pyrokinetics.yml
+++ b/.github/workflows/check_pyrokinetics.yml
@@ -50,6 +50,7 @@ jobs:
           sudo apt install -y gfortran make libfftw3-dev libnetcdf-dev libnetcdff-dev 
           sudo apt install -y netcdf-bin python3 python3-pip openmpi-bin libopenmpi-dev
           pip3 install --user -r AUTOMATIC_TESTS/requirements.txt
+          source AUTOMATIC_TESTS/venv/bin/activate
           pip3 install EXTERNALS/pyrokinetics/.
           sed -i 's/nproc = 16/nproc = 1/g' AUTOMATIC_TESTS/config.ini
           

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "externals/neasyf"]
 	path = EXTERNALS/neasyf
 	url = https://github.com/PlasmaFAIR/neasy-f.git
+[submodule "EXTERNALS/pyrokinetics"]
+	path = EXTERNALS/pyrokinetics
+	url = https://github.com/pyro-kinetics/pyrokinetics

--- a/AUTOMATIC_TESTS/Makefile
+++ b/AUTOMATIC_TESTS/Makefile
@@ -49,6 +49,11 @@ numerical-tests-7: check-tests-dependencies $(PROJECT_DIR)/stella
 numerical-tests-system:
 	@python3 $(TEST_DIR)/system_information.py
 	
+# Run the automated stella tests (the -r flag shows the full stella output and -rf shows extra info about the failed outputs)
+pyrokinetics-tests: check-tests-dependencies $(PROJECT_DIR)/stella
+	@echo "Running: automated stella tests for pyrokinetics"
+	@python3 -m pytest -v -rF -W ignore::DeprecationWarning $(TEST_DIR)/pyrokinetics_tests/
+	
 # Run the automated stella tests (the -r flag shows the full stella output)
 # -rA shows all outputs, -rf shows only failed outputs 
 numerical-tests-verbose: check-tests-dependencies $(PROJECT_DIR)/stella

--- a/AUTOMATIC_TESTS/check_automated_stella_tests_requirements.py
+++ b/AUTOMATIC_TESTS/check_automated_stella_tests_requirements.py
@@ -14,7 +14,10 @@ requirements = []
 for line in contents:
     if line.startswith("#"):
         continue
+    if line.replace(' ','').replace('\n','').replace('\t','')=='':
+        continue
     module = line.split("=")[0]
+    if 'pyrokinetics' in line: module = 'pyrokinetics'
     requirements.append(module.replace(">", "").replace("~", "").replace("\n", ""))
 
 failed_modules = []

--- a/AUTOMATIC_TESTS/check_automated_stella_tests_requirements.py
+++ b/AUTOMATIC_TESTS/check_automated_stella_tests_requirements.py
@@ -36,6 +36,7 @@ if failed_modules:
             Run:
                 make create-test-virtualenv
                 source AUTOMATIC_TESTS/venv/bin/activate
+                pip install EXTERNALS/pyrokinetics/.
             to install and activate test dependencies
             """
         )

--- a/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/empty.in
+++ b/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/empty.in
@@ -1,0 +1,38 @@
+
+! Smallest possible input file that runs without errors
+! and that runs fast, hence we set (nkx,nky,nzed,nmu,nvpa)
+
+&parameters_numerical
+  nstep=10
+/
+&stella_diagnostics_knobs
+  nwrite = 1
+/
+&species_parameters_1 
+/
+&kt_grids_knobs
+  grid_option='range'
+/
+&kt_grids_range_parameters
+  naky = 10
+  aky_min = 0.1
+  aky_max = 1.0
+  nakx = 1
+  akx_min = 0.0
+  akx_max = 0.0
+/
+&zgrid_parameters 
+  nzed = 8
+/
+&vpamu_grids_parameters
+  nmu = 4 
+  nvgrid = 6 
+/
+&millergeo_parameters
+  rhoc = 0.5
+  shat = 0.796
+  qinp = 1.4
+  rmaj = 2.77778
+  rgeo = 2.77778
+  kappa = 1.0
+/ 

--- a/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/miller_linear_CBC.in
+++ b/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/miller_linear_CBC.in
@@ -1,0 +1,97 @@
+ 
+! Simple linear example using CBC
+
+&parameters_physics
+  adiabatic_option = 'iphi00=2'
+  full_flux_surface = .false.
+  include_apar = .false.
+  nonlinear = .false.
+  vnew_ref = 0.01
+/
+&parameters_numerical
+  delt = 0.05 
+  nstep = 10
+  print_extra_info_to_terminal = .false.
+/
+&stella_diagnostics_knobs
+  nsave = 10
+  nwrite = 1
+  save_for_restart = .false.
+  write_all = .true.
+/
+&species_knobs
+  nspec = 2
+  species_option = 'stella'
+/
+&species_parameters_1
+  dens = 1.0
+  fprim = 1.0
+  mass = 1.0
+  temp = 1.0
+  tprim = 3.0
+  type = 'ion'
+  z = 1.0
+/
+&species_parameters_2
+  dens = 1.0
+  fprim = 1.0
+  mass = 0.0005446
+  temp = 1.0
+  tprim = 3.0
+  type = 'electron'
+  z = -1.0
+/
+&kt_grids_knobs
+  grid_option='range'
+/
+&kt_grids_range_parameters
+  naky = 10
+  aky_min = 0.1
+  aky_max = 1.0
+  nakx = 1
+  akx_min = 0.0
+  akx_max = 0.0
+/
+&zgrid_parameters
+  boundary_option = 'zero'
+  nperiod = 1
+  nzed = 8
+/
+&vpamu_grids_parameters
+  nmu = 4 
+  nvgrid = 6 
+/
+&init_g_knobs
+  ginit_option = 'noise'
+  phiinit = 0.01
+/
+&dissipation
+  hyper_dissipation = .true.
+/
+&geo_knobs
+  geo_option = 'miller'
+/
+&time_advance_knobs 
+  explicit_option = 'rk2'
+/
+&layouts_knobs
+  vms_layout = 'vms'
+  xyzs_layout = 'yxzs'
+/
+&millergeo_parameters
+  nzed_local = 128
+  rhoc = 0.5
+  shat = 0.796
+  qinp = 1.4
+  rmaj = 2.77778
+  rgeo = 2.77778
+  shift = 0.0
+  kappa = 1.0
+  kapprim = 0.0
+  tri = 0.0
+  triprim = 0.0
+  betaprim = 0.0
+  d2qdr2 = 0.0
+  d2psidr2 = 0.0
+  betadbprim = 0.0
+/ 

--- a/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/miller_linear_CBC_old.in
+++ b/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/miller_linear_CBC_old.in
@@ -1,0 +1,96 @@
+ 
+! Simple linear example using CBC
+
+&physics_flags
+  adiabatic_option = 'iphi00=2'
+  full_flux_surface = .false.
+  include_apar = .false.
+  nonlinear = .false.
+/
+&species_knobs
+  nspec = 2
+  species_option = 'stella'
+/
+&species_parameters_1
+  dens = 1.0
+  fprim = 1.0
+  mass = 1.0
+  temp = 1.0
+  tprim = 3.0
+  type = 'ion'
+  z = 1.0
+/
+&species_parameters_2
+  dens = 1.0
+  fprim = 1.0
+  mass = 0.0005446
+  temp = 1.0
+  tprim = 3.0
+  type = 'electron'
+  z = -1.0
+/
+&kt_grids_knobs
+  grid_option='range'
+/
+&kt_grids_range_parameters
+  naky = 10
+  aky_min = 0.1
+  aky_max = 1.0
+  nakx = 1
+  akx_min = 0.0
+  akx_max = 0.0
+/
+&zgrid_parameters
+  boundary_option = 'zero'
+  nperiod = 1
+  nzed = 8
+/
+&vpamu_grids_parameters
+  nmu = 4 
+  nvgrid = 6 
+/
+&knobs
+  delt = 0.05 
+  nstep = 1000
+  print_extra_info_to_terminal = .false.  
+/
+&stella_diagnostics_knobs
+  nsave = 100
+  nwrite = 10
+  save_for_restart = .false.
+  write_all = .true.
+/
+&init_g_knobs
+  ginit_option = 'noise'
+  phiinit = 0.01
+/
+&dissipation
+  hyper_dissipation = .true.
+/
+&geo_knobs
+  geo_option = 'miller'
+/
+&time_advance_knobs 
+  explicit_option = 'rk2'
+/
+&layouts_knobs
+  vms_layout = 'vms'
+  xyzs_layout = 'yxzs'
+/
+&millergeo_parameters
+  nzed_local = 128
+  rhoc = 0.5
+  shat = 0.796
+  qinp = 1.4
+  rmaj = 2.77778
+  rgeo = 2.77778
+  shift = 0.0
+  kappa = 1.0
+  kapprim = 0.0
+  tri = 0.0
+  triprim = 0.0
+  betaprim = 0.0
+  d2qdr2 = 0.0
+  d2psidr2 = 0.0
+  betadbprim = 0.0
+/ 

--- a/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/miller_linear_CBC_quick.in
+++ b/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/miller_linear_CBC_quick.in
@@ -1,0 +1,96 @@
+ 
+! Simple linear example using CBC
+
+&physics_flags
+  adiabatic_option = 'iphi00=2'
+  full_flux_surface = .false.
+  include_apar = .false.
+  nonlinear = .false.
+/
+&species_knobs
+  nspec = 2
+  species_option = 'stella'
+/
+&species_parameters_1
+  dens = 1.0
+  fprim = 1.0
+  mass = 1.0
+  temp = 1.0
+  tprim = 3.0
+  type = 'ion'
+  z = 1.0
+/
+&species_parameters_2
+  dens = 1.0
+  fprim = 1.0
+  mass = 0.0005446
+  temp = 1.0
+  tprim = 3.0
+  type = 'electron'
+  z = -1.0
+/
+&kt_grids_knobs
+  grid_option='range'
+/
+&kt_grids_range_parameters
+  naky = 10
+  aky_min = 0.1
+  aky_max = 1.0
+  nakx = 1
+  akx_min = 0.0
+  akx_max = 0.0
+/
+&zgrid_parameters
+  boundary_option = 'zero'
+  nperiod = 1
+  nzed = 8
+/
+&vpamu_grids_parameters
+  nmu = 4 
+  nvgrid = 6 
+/
+&knobs
+  delt = 0.05 
+  nstep = 10
+  print_extra_info_to_terminal = .false.  
+/
+&stella_diagnostics_knobs
+  nsave = 10
+  nwrite = 1
+  save_for_restart = .false.
+  write_all = .true.
+/
+&init_g_knobs
+  ginit_option = 'noise'
+  phiinit = 0.01
+/
+&dissipation
+  hyper_dissipation = .true.
+/
+&geo_knobs
+  geo_option = 'miller'
+/
+&time_advance_knobs 
+  explicit_option = 'rk2'
+/
+&layouts_knobs
+  vms_layout = 'vms'
+  xyzs_layout = 'yxzs'
+/
+&millergeo_parameters
+  nzed_local = 128
+  rhoc = 0.5
+  shat = 0.796
+  qinp = 1.4
+  rmaj = 2.77778
+  rgeo = 2.77778
+  shift = 0.0
+  kappa = 1.0
+  kapprim = 0.0
+  tri = 0.0
+  triprim = 0.0
+  betaprim = 0.0
+  d2qdr2 = 0.0
+  d2psidr2 = 0.0
+  betadbprim = 0.0
+/ 

--- a/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/test_1a_whether_stella_runs.py
+++ b/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/test_1a_whether_stella_runs.py
@@ -1,0 +1,131 @@
+################################################################################
+#              Check whether pyrokinetics can plot stella output               #
+################################################################################
+
+# Python modules
+import os, sys
+import pathlib 
+import numpy as np
+import xarray as xr  
+
+# Package to run stella 
+module_path = str(pathlib.Path(__file__).parent.parent.parent / 'run_local_stella_simulation.py')
+with open(module_path, 'r') as file: exec(file.read())
+
+# Global variables  
+input_filename = 'miller_linear_CBC.in'  
+local_stella_run_directory = 'Not/Run/Yet'
+
+#-------------------------------------------------------------------------------
+#                         Run local stella simulation                          #
+#-------------------------------------------------------------------------------
+def test_whether_we_can_run_a_local_stella_simulation(tmp_path):
+    '''Run a local stella simulation in a temporary folder <tmp_path>.'''  
+    
+    # Save the temporary folder <tmp_path> as a global variable so the
+    # other tests can access the output files from the local stella run.
+    global local_stella_run_directory
+    local_stella_run_directory = tmp_path
+    
+    # Run stella inside of <tmp_path> based on <input_filename>
+    run_local_stella_simulation(input_filename, tmp_path)
+    print('\n  -->  Successfully ran a local stella simulation.')
+    return 
+    
+#-------------------------------------------------------------------------------
+#                    Check whether output files are present                    #
+#-------------------------------------------------------------------------------
+def test_whether_all_output_files_are_gerenated_when_running_stella(error=False):  
+    '''To ensure that stella ran correctly, check that all output files are generated.'''
+    
+    # Gather the output files generated during the local stella run inside <tmp_path>
+    local_files = os.listdir(local_stella_run_directory)
+    
+    # Create a list of the output files we expect when stella has been run
+    stem = input_filename.replace('.in','')
+    expected_files = ['in', 'out.nc', 'geometry', 'fluxes', 'omega', 'out', 'final_fields', 'species.input', 'error']
+    expected_files = [stem+'.'+extension for extension in expected_files]
+    
+    # Check whether all these output files are present
+    for expected_file in expected_files:
+        if not (expected_file in local_files):
+            print(f'ERROR: The "{expected_file}" output file was not generated when running stella.'); error = True
+            
+    # The <pytest> module will check whether all <assert> statements are true,
+    # if it runs into a statement which is false, the test will be labeled as
+    # "Failed" and the string in the second argument of the <assert> statement 
+    # will be printed to the command prompt as "AssertionError: <error message>"
+    assert (not error), f'Some output files were not generated when running stella.'
+    
+    # The test will stop as soon as an <assert> error was triggered, hence we
+    # will only reach this final line of code if the test ran successfully
+    print(f'  -->  All the expected files (.in, .geometry, .out.nc, .fluxes, .omega, ...) are generated.')
+    return 
+        
+#-------------------------------------------------------------------------------
+#         Check whether all quantities are present in the netcdf file          #
+#-------------------------------------------------------------------------------
+def test_whether_correct_quantities_are_present_in_netcdf_file(error=False):
+    '''Check whether the correct quantities are present in the netcdf output file.''' 
+    
+    # Find the netcdf output file which was generated during our local stella run
+    local_netcdf_file = local_stella_run_directory / input_filename.replace('.in', '.out.nc')
+    
+    # Open the netcdf file
+    with xr.open_dataset(local_netcdf_file) as local_netcdf:
+    
+        # Check whether all the dimensions are present in the netcdf file
+        expected_keys = ['kx', 'ky', 'tube', 'zed', 'alpha', 'vpa', 'mu', 'species', 't', 'char10', 'char200', 'ri']  
+        for key in expected_keys:
+            if (key not in local_netcdf): print(f'ERROR: The quantity {key} could not be found in the netcdf file.'); error = True
+        if not error: print(f'  -->  The netcdf file contains the following dimensions: {expected_keys}.')  
+    
+        # Check whether all the species information is present in the netcdf file
+        expected_keys = ['charge', 'mass', 'dens', 'temp', 'tprim', 'fprim', 'vnew', 'type_of_species'] 
+        for key in expected_keys:
+            if (key not in local_netcdf): print(f'ERROR: The quantity {key} could not be found in the netcdf file.'); error = True
+        if not error: print(f'  -->  The netcdf file contains the following species information: {expected_keys}.')
+         
+        # Check whether all the geometry data is present in the netcdf file
+        expected_keys = ['bmag', 'b_dot_grad_z', 'gradpar', 'gbdrift', 'gbdrift0', 'cvdrift', 'cvdrift0', 'kperp2', \
+            'gds2', 'gds21', 'gds22', 'grho', 'jacob', 'djacdrho', 'beta', 'q', 'shat', 'd2qdr2', 'drhodpsi', 'd2psidr2', 'jtwist'] 
+        for key in expected_keys:
+            if (key not in local_netcdf): print(f'ERROR: The quantity {key} could not be found in the netcdf file.'); error = True
+        if not error: print(f'  -->  The netcdf file contains the following geometry data: {expected_keys}.')
+        
+        # Check whether all the diagnostics data is present in the netcdf file
+        dist_extensions = ['_vs_vpamus', '_vs_zvpas', '_vs_zmus', '_vs_zvpamus']
+        expected_keys = ['t', 'omega', 'phi2', 'apar2', 'bpar2', 'omega']; new_keys = True
+        expected_keys += [i+j for i in ['pflux', 'qflux', 'vflux'] for j in ['_vs_s', '_vs_kxkyzs']]
+        expected_keys += [i+j for i in ['g2', 'h2', 'f2', 'g2nozonal', 'h2nozonal', 'f2nozonal'] for j in dist_extensions]
+        expected_keys += ['g2_vs_zkykxs', 'h2_vs_zkykxs', 'f2_vs_zkykxs']
+        for key in expected_keys:
+            if (key not in local_netcdf): 
+                print(f'ERROR: The quantity {key} could not be found in the netcdf file.'); new_keys = False
+            
+        # Try old stella names
+        if new_keys==False:
+            print('--------------------------------------------------')
+            print(' The new stella keys werent found, try old keys.')
+            print('--------------------------------------------------')
+            expected_keys = ['t', 'omega', 'phi2', 'apar2', 'bpar2', 'pflx', 'vflx', 'phi_vs_t', 'phi2_vs_kxky', \
+               'pflx_vs_kxky', 'vflx_vs_kxky', 'qflx_vs_kxky', 'pflux_x', 'vflux_x', 'qflux_x', \
+               'dens_x', 'upar_x', 'temp_x', 'pflx_kxky', 'vflx_kxky', 'qflx_kxky', 'gvmus', 'gzvs']  
+            for key in expected_keys:
+               if (key not in local_netcdf): 
+                   print(f'ERROR: The quantity {key} could not be found in the netcdf file.'); error = True
+                       
+        if not error: print(f'  -->  The netcdf file contains the following diagnostics data: {expected_keys}.')
+            
+        # The <pytest> module will check whether all <assert> statements are true,
+        # if it runs into a statement which is false, the test will be labeled as
+        # "Failed" and the string in the second argument of the <assert> statement 
+        # will be printed to the command prompt as "AssertionError: <error message>"
+        assert (not error), f'Some quantities were not found in the netcdf file.' 
+        
+        # The test will stop as soon as an <assert> error was triggered, hence we
+        # will only reach this final line of code if the test ran successfully
+        print(f'  -->  The netcdf file contains all the expected data.')
+        
+    return 
+     

--- a/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/test_1b_whether_pyrokinetics_loads.py
+++ b/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/test_1b_whether_pyrokinetics_loads.py
@@ -1,0 +1,40 @@
+################################################################################
+#              Check whether pyrokinetics can plot stella output               #
+################################################################################
+
+# Python modules
+import os, sys
+import pathlib 
+import numpy as np
+import xarray as xr  
+
+# Package to run stella 
+module_path = str(pathlib.Path(__file__).parent.parent.parent / 'run_local_stella_simulation.py')
+with open(module_path, 'r') as file: exec(file.read())
+
+# Pyrokinetics package
+from pyrokinetics import Pyro
+
+# Global variables  
+input_filename = 'miller_linear_CBC.in'  
+local_stella_run_directory = 'Not/Run/Yet'
+
+#-------------------------------------------------------------------------------
+#                         Run local stella simulation                          #
+#-------------------------------------------------------------------------------
+def test_whether_we_can_load_pyrokinetics(tmp_path):
+    '''Run a local stella simulation in a temporary folder <tmp_path>.'''  
+    
+    # Save the temporary folder <tmp_path> as a global variable so the
+    # other tests can access the output files from the local stella run.
+    global local_stella_run_directory
+    local_stella_run_directory = tmp_path
+    
+    # Run stella inside of <tmp_path> based on <input_filename>
+    run_local_stella_simulation(input_filename, tmp_path) 
+    
+    # Load the pyro data
+    local_input_file = local_stella_run_directory / input_filename
+    pyro = Pyro(gk_file=local_input_file, gk_code="STELLA")
+    print('\n  -->  Successfully loaded pyrokinetics.')
+    return

--- a/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/test_1c_whether_pyrokinetics_loads_for_empty_input.py
+++ b/AUTOMATIC_TESTS/pyrokinetics_tests/test_1_whether_pyrokinetics_loads/test_1c_whether_pyrokinetics_loads_for_empty_input.py
@@ -1,0 +1,41 @@
+################################################################################
+#              Check whether pyrokinetics can plot stella output               #
+################################################################################
+
+# Python modules
+import os, sys
+import pathlib 
+import numpy as np
+import xarray as xr  
+
+# Package to run stella 
+module_path = str(pathlib.Path(__file__).parent.parent.parent / 'run_local_stella_simulation.py')
+with open(module_path, 'r') as file: exec(file.read())
+
+# Pyrokinetics package
+from pyrokinetics import Pyro
+
+# Global variables  
+input_filename = 'empty.in'  
+local_stella_run_directory = 'Not/Run/Yet'
+
+#-------------------------------------------------------------------------------
+#                         Run local stella simulation                          #
+#-------------------------------------------------------------------------------
+def TODO_test_whether_we_can_load_pyrokinetics(tmp_path):
+    '''Run a local stella simulation in a temporary folder <tmp_path>.'''  
+    
+    # Save the temporary folder <tmp_path> as a global variable so the
+    # other tests can access the output files from the local stella run.
+    global local_stella_run_directory
+    local_stella_run_directory = tmp_path
+    
+    # Run stella inside of <tmp_path> based on <input_filename>
+    run_local_stella_simulation(input_filename, tmp_path) 
+    
+    # Load the pyro data
+    local_input_file = local_stella_run_directory / input_filename
+    pyro = Pyro(gk_file=local_input_file, gk_code="STELLA")
+    print('\n  -->  Successfully loaded pyrokinetics.')
+    return 
+

--- a/AUTOMATIC_TESTS/requirements.txt
+++ b/AUTOMATIC_TESTS/requirements.txt
@@ -8,6 +8,3 @@ setuptools==66.1.1
 configparser
 matplotlib
 h5py
-
-# Install pyrokinetics
-./../EXTERNALS/pyrokinetics/.

--- a/AUTOMATIC_TESTS/requirements.txt
+++ b/AUTOMATIC_TESTS/requirements.txt
@@ -8,3 +8,6 @@ setuptools==66.1.1
 configparser
 matplotlib
 h5py
+
+# Install pyrokinetics
+./../EXTERNALS/pyrokinetics/.


### PR DESCRIPTION
Only the start of these automatic tests have been implemented. To continue it would be useful if stella printed the default variables, since pyrokinetics requires the following namelists to be present:

"parameters_numerical"
"zgrid_parameters"
"geo_knobs"
"millergeo_parameters"
"parameters_physics"
"species_knobs"
"kt_grids_knobs"