### PR TITLE
Update default Miller parameters to those of the Cyclone Base Case (CBC)

### DIFF
--- a/STELLA_CODE/geometry/geometry_miller.f90
+++ b/STELLA_CODE/geometry/geometry_miller.f90
@@ -77,12 +77,12 @@ contains
       nzed_local = 128
       rhoc = 0.5
       rhoc0 = 0.5
-      rmaj = 3.0
-      rgeo = 3.0
+      rmaj = 2.77778
+      rgeo = 2.77778
       qinp = 1.4
-      shat = 0.8
+      shat = 0.796
       shift = 0.0
-      kappa = 0.0
+      kappa = 1.0
       kapprim = 0.0
       tri = 0.0
       triprim = 0.0


### PR DESCRIPTION
An empty input file would not run on stella since "kappa=0" by default. I've updated the default Miller parameters to correspond to the Cyclone Base Case (CBC). This way, if someone does not specify a Miller input, a reasonable geometry is created.