### PR TITLE
Add support for new IntelLLVM compilers

### DIFF
--- a/COMPILATION/CMakeLists.txt
+++ b/COMPILATION/CMakeLists.txt
@@ -243,6 +243,8 @@ if (STELLA_ENABLE_DOUBLE)
       -fdefault-real-8 -fdefault-double-8 >
     $<$<Fortran_COMPILER_ID:Intel>:
       -r8 >
+    $<$<Fortran_COMPILER_ID:IntelLLVM>:
+      -r8 >
     $<$<Fortran_COMPILER_ID:Cray>:
       -s real64 >
     )
@@ -269,6 +271,7 @@ target_link_libraries(libstella PUBLIC fortran_git::fortran_git)
 target_compile_definitions(libstella PRIVATE
   $<$<Fortran_COMPILER_ID:GNU>:FCOMPILER=_GFORTRAN_>
   $<$<Fortran_COMPILER_ID:Intel>:FCOMPILER=_INTEL_>
+  $<$<Fortran_COMPILER_ID:IntelLLVM>:FCOMPILER=_INTEL_>
   $<$<Fortran_COMPILER_ID:Cray>:FCOMPILER=_CRAY_>
   )
   
@@ -290,6 +293,8 @@ target_compile_options(libstella PRIVATE
       -g -Wall -fimplicit-none -fbounds-check >
     $<$<Fortran_COMPILER_ID:Intel>:
       -g -implicitnone -warn all -nogen-interfaces -CB -traceback >
+    $<$<Fortran_COMPILER_ID:IntelLLVM>:
+      -g -warn all -CB -traceback >
     $<$<Fortran_COMPILER_ID:Cray>:
       -g -Rb >
     >

--- a/STELLA_CODE/utils/CMakeLists.txt
+++ b/STELLA_CODE/utils/CMakeLists.txt
@@ -83,6 +83,8 @@ if (STELLA_ENABLE_DOUBLE)
       -fdefault-real-8 -fdefault-double-8 >
     $<$<Fortran_COMPILER_ID:Intel>:
       -r8 >
+    $<$<Fortran_COMPILER_ID:IntelLLVM>:
+      -r8 >
     )
   set(STELLA_DEFAULT_REAL_KIND "double")
 else()
@@ -131,6 +133,7 @@ target_compile_definitions(stella_utils PRIVATE
 target_compile_definitions(stella_utils PRIVATE
   $<$<Fortran_COMPILER_ID:GNU>:FCOMPILER=_GFORTRAN_>
   $<$<Fortran_COMPILER_ID:Intel>:FCOMPILER=_INTEL_>
+  $<$<Fortran_COMPILER_ID:IntelLLVM>:FCOMPILER=_INTEL_>
   )
 
 find_package(MPI)


### PR DESCRIPTION
As the classic Intel Fortran compiler `ifort` is now deprecated for [almost a year](https://community.intel.com/t5/Blogs/Tech-Innovation/Tools/Deprecation-of-The-Intel-Fortran-Compiler-Classic-ifort/post/1541699) i added some simple extensions to the CMake setup to make sure Stella builds on newer compilers. 

I tested this in Marenostrum 5 with the `intel/2025.1` release and seems to work :)

```
   ---------------------------------
     stella Configuration Summary
   ---------------------------------

   LAPACK support           : ON
   FFTW support             : ON
   NetCDF support           : ON
   Default real kind        : double
   POSIX support            : OFF
   Use F2003/8 intrinsics   : OFF
   Compilation flags        :  -O2 -g
   Build type               : RelWithDebInfo
   Compiler                 : /gpfs/apps/MN5/GPP/ONEAPI/2025.1/compiler/latest/bin/ifx
   
   ... 
   
   [100%] Built target stella
```
