### PR TITLE
Make Stella compile again with IntelLLVM Compilers (ifx)

### DIFF
--- a/STELLA_CODE/read_namelists_from_input_file/namelist_diagnostics.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_diagnostics.f90
@@ -215,17 +215,17 @@ contains
          write (unit, '(A, I0)') '  nsave = ', nsave
          write (unit, '(A, I0)') '  nwrite = ', nwrite
          write (unit, '(A, I0)') '  nc_mult = ', nc_mult
-         write (unit, '(A, L0)') '  save_for_restart = ', save_for_restart
-         write (unit, '(A, L0)') '  write_all = ', write_all
-         write (unit, '(A, L0)') '  write_all_time_traces = ', write_all_time_traces
-         write (unit, '(A, L0)') '  write_all_spectra_kxkyz = ', write_all_spectra_kxkyz
-         write (unit, '(A, L0)') '  write_all_spectra_kxky = ', write_all_spectra_kxky
-         write (unit, '(A, L0)') '  write_all_velocity_space = ', write_all_velocity_space
-         write (unit, '(A, L0)') '  write_all_potential = ', write_all_potential
-         write (unit, '(A, L0)') '  write_all_omega = ', write_all_omega
-         write (unit, '(A, L0)') '  write_all_distribution = ', write_all_distribution
-         write (unit, '(A, L0)') '  write_all_fluxes = ', write_all_fluxes
-         write (unit, '(A, L0)') '  write_all_moments = ', write_all_moments
+         write (unit, '(A, L1)') '  save_for_restart = ', save_for_restart
+         write (unit, '(A, L1)') '  write_all = ', write_all
+         write (unit, '(A, L1)') '  write_all_time_traces = ', write_all_time_traces
+         write (unit, '(A, L1)') '  write_all_spectra_kxkyz = ', write_all_spectra_kxkyz
+         write (unit, '(A, L1)') '  write_all_spectra_kxky = ', write_all_spectra_kxky
+         write (unit, '(A, L1)') '  write_all_velocity_space = ', write_all_velocity_space
+         write (unit, '(A, L1)') '  write_all_potential = ', write_all_potential
+         write (unit, '(A, L1)') '  write_all_omega = ', write_all_omega
+         write (unit, '(A, L1)') '  write_all_distribution = ', write_all_distribution
+         write (unit, '(A, L1)') '  write_all_fluxes = ', write_all_fluxes
+         write (unit, '(A, L1)') '  write_all_moments = ', write_all_moments
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
 

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_dissipation.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_dissipation.f90
@@ -169,11 +169,11 @@ contains
          !-------------------------------------------------------------------------
 
          write (unit, '(A)') '&dissipation_and_collisions_options'
-         write (unit, '(A, L0)') '  hyper_dissipation = ', hyper_dissipation
-         write (unit, '(A, L0)') '  include_collisions = ', include_collisions
+         write (unit, '(A, L1)') '  hyper_dissipation = ', hyper_dissipation
+         write (unit, '(A, L1)') '  include_collisions = ', include_collisions
          write (unit, '(A, A, A)') '  collision_model = "', trim(collision_model),'"'
-         write (unit, '(A, L0)') '  collisions_implicit = ', collisions_implicit
-         write (unit, '(A, L0)') '  ecoll_zeff = ', ecoll_zeff
+         write (unit, '(A, L1)') '  collisions_implicit = ', collisions_implicit
+         write (unit, '(A, L1)') '  ecoll_zeff = ', ecoll_zeff
          write (unit, '(A, ES0.4)') '  zeff = ', zeff
          write (unit, '(A, ES0.4)') '  vnew_ref = ', vnew_ref
          write (unit, '(A)') '/'
@@ -240,10 +240,10 @@ contains
          !-------------------------------------------------------------------------
 
          write (unit, '(A)') '&collisions_dougherty'
-         write (unit, '(A, L0)') '  momentum_conservation = ', momentum_conservation
-         write (unit, '(A, L0)') '  energy_conservation = ', energy_conservation
-         write (unit, '(A, L0)') '  vpa_operator = ', vpa_operator
-         write (unit, '(A, L0)') '  mu_operator = ', mu_operator
+         write (unit, '(A, L1)') '  momentum_conservation = ', momentum_conservation
+         write (unit, '(A, L1)') '  energy_conservation = ', energy_conservation
+         write (unit, '(A, L1)') '  vpa_operator = ', vpa_operator
+         write (unit, '(A, L1)') '  mu_operator = ', mu_operator
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
          
@@ -359,23 +359,23 @@ contains
          !-------------------------------------------------------------------------
 
          write (unit, '(A)') '&collisions_fokker_planck'
-         write (unit, '(A, L0)') '  fieldpart = ', fieldpart
-         write (unit, '(A, L0)') '  testpart = ', testpart
-         write (unit, '(A, L0)') '  interspec = ', interspec
-         write (unit, '(A, L0)') '  intraspec = ', intraspec
-         write (unit, '(A, L0)') '  eimassr_approx = ', eimassr_approx
-         write (unit, '(A, L0)') '  advfield_coll = ', advfield_coll
-         write (unit, '(A, L0)') '  spitzer_problem = ', spitzer_problem
-         write (unit, '(A, L0)') '  density_conservation = ', density_conservation
-         write (unit, '(A, L0)') '  density_conservation_field = ', density_conservation_field
-         write (unit, '(A, L0)') '  density_conservation_tp = ', density_conservation_tp
-         write (unit, '(A, L0)') '  exact_conservation_tp = ', exact_conservation_tp
-         write (unit, '(A, L0)') '  exact_conservation = ', exact_conservation
-         write (unit, '(A, L0)') '  vpa_operator = ', vpa_operator
-         write (unit, '(A, L0)') '  mu_operator = ', mu_operator
-         write (unit, '(A, L0)') '  no_j1l1 = ', no_j1l1
-         write (unit, '(A, L0)') '  no_j1l2 = ', no_j1l2
-         write (unit, '(A, L0)') '  no_j0l2 = ', no_j0l2
+         write (unit, '(A, L1)') '  fieldpart = ', fieldpart
+         write (unit, '(A, L1)') '  testpart = ', testpart
+         write (unit, '(A, L1)') '  interspec = ', interspec
+         write (unit, '(A, L1)') '  intraspec = ', intraspec
+         write (unit, '(A, L1)') '  eimassr_approx = ', eimassr_approx
+         write (unit, '(A, L1)') '  advfield_coll = ', advfield_coll
+         write (unit, '(A, L1)') '  spitzer_problem = ', spitzer_problem
+         write (unit, '(A, L1)') '  density_conservation = ', density_conservation
+         write (unit, '(A, L1)') '  density_conservation_field = ', density_conservation_field
+         write (unit, '(A, L1)') '  density_conservation_tp = ', density_conservation_tp
+         write (unit, '(A, L1)') '  exact_conservation_tp = ', exact_conservation_tp
+         write (unit, '(A, L1)') '  exact_conservation = ', exact_conservation
+         write (unit, '(A, L1)') '  vpa_operator = ', vpa_operator
+         write (unit, '(A, L1)') '  mu_operator = ', mu_operator
+         write (unit, '(A, L1)') '  no_j1l1 = ', no_j1l1
+         write (unit, '(A, L1)') '  no_j1l2 = ', no_j1l2
+         write (unit, '(A, L1)') '  no_j0l2 = ', no_j0l2
          write (unit, '(A, I0)') '  jmax = ', jmax
          write (unit, '(A, I0)') '  lmax = ', lmax
          write (unit, '(A, I0)') '  nvel_local = ', nvel_local
@@ -477,10 +477,10 @@ contains
          !-------------------------------------------------------------------------
 
          write (unit, '(A)') '&hyper_dissipation'
-         write (unit, '(A, L0)') '  use_physical_ksqr = ', use_physical_ksqr
-         write (unit, '(A, L0)') '  scale_to_outboard = ', scale_to_outboard
-         write (unit, '(A, L0)') '  hyp_vpa = ', hyp_vpa
-         write (unit, '(A, L0)') '  hyp_zed = ', hyp_zed
+         write (unit, '(A, L1)') '  use_physical_ksqr = ', use_physical_ksqr
+         write (unit, '(A, L1)') '  scale_to_outboard = ', scale_to_outboard
+         write (unit, '(A, L1)') '  hyp_vpa = ', hyp_vpa
+         write (unit, '(A, L1)') '  hyp_zed = ', hyp_zed
          write (unit, '(A, ES0.4)') '  D_hyper = ', D_hyper
          write (unit, '(A, ES0.4)') '  D_zed = ', D_zed
          write (unit, '(A, ES0.4)') '  D_vpa = ', D_vpa

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_flow_shear.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_flow_shear.f90
@@ -95,8 +95,8 @@ contains
          !-------------------------------------------------------------------------
 
          write (unit, '(A)') '&flow_shear'
-         write (unit, '(A, L0)') '  prp_shear_enabled = ', prp_shear_enabled
-         write (unit, '(A, L0)') '  hammett_flow_shear = ', hammett_flow_shear
+         write (unit, '(A, L1)') '  prp_shear_enabled = ', prp_shear_enabled
+         write (unit, '(A, L1)') '  hammett_flow_shear = ', hammett_flow_shear
          write (unit, '(A, ES0.4)') '  g_exb = ', g_exb
          write (unit, '(A, ES0.4)') '  g_exbfac = ', g_exbfac
          write (unit, '(A, ES0.4)') '  omprimfac = ', omprimfac

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_geometry.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_geometry.f90
@@ -227,7 +227,7 @@ contains
 
          write (unit, '(A)') '&geometry_options'
          write (unit, '(A, A, A)') '  geometry_option = "', trim(geometry_option),'"'
-         write (unit, '(A, L0)') '  q_as_x = ', q_as_x
+         write (unit, '(A, L1)') '  q_as_x = ', q_as_x
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
 
@@ -331,16 +331,16 @@ contains
 
          write (unit, '(A)') '&geometry_from_txt'
          write (unit, '(A, A, A)') '  geometry_file = "', trim(geometry_file),'"'
-         write (unit, '(A, L0)') '  overwrite_bmag = ', overwrite_bmag
-         write (unit, '(A, L0)') '  overwrite_b_dot_gradzeta = ', overwrite_b_dot_gradzeta
-         write (unit, '(A, L0)') '  overwrite_grady_dot_grady = ', overwrite_grady_dot_grady
-         write (unit, '(A, L0)') '  overwrite_gradx_dot_grady = ', overwrite_gradx_dot_grady
-         write (unit, '(A, L0)') '  overwrite_gradx_dot_gradx = ', overwrite_gradx_dot_gradx
-         write (unit, '(A, L0)') '  overwrite_gds23 = ', overwrite_gds23
-         write (unit, '(A, L0)') '  overwrite_gds24 = ', overwrite_gds24
-         write (unit, '(A, L0)') '  overwrite_B_times_kappa_dot_grady = ', overwrite_B_times_kappa_dot_grady
-         write (unit, '(A, L0)') '  overwrite_B_times_gradB_dot_grady = ', overwrite_B_times_gradB_dot_grady
-         write (unit, '(A, L0)') '  overwrite_B_times_gradB_dot_gradx = ', overwrite_B_times_gradB_dot_gradx
+         write (unit, '(A, L1)') '  overwrite_bmag = ', overwrite_bmag
+         write (unit, '(A, L1)') '  overwrite_b_dot_gradzeta = ', overwrite_b_dot_gradzeta
+         write (unit, '(A, L1)') '  overwrite_grady_dot_grady = ', overwrite_grady_dot_grady
+         write (unit, '(A, L1)') '  overwrite_gradx_dot_grady = ', overwrite_gradx_dot_grady
+         write (unit, '(A, L1)') '  overwrite_gradx_dot_gradx = ', overwrite_gradx_dot_gradx
+         write (unit, '(A, L1)') '  overwrite_gds23 = ', overwrite_gds23
+         write (unit, '(A, L1)') '  overwrite_gds24 = ', overwrite_gds24
+         write (unit, '(A, L1)') '  overwrite_B_times_kappa_dot_grady = ', overwrite_B_times_kappa_dot_grady
+         write (unit, '(A, L1)') '  overwrite_B_times_gradB_dot_grady = ', overwrite_B_times_gradB_dot_grady
+         write (unit, '(A, L1)') '  overwrite_B_times_gradB_dot_gradx = ', overwrite_B_times_gradB_dot_gradx
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
 
@@ -447,8 +447,8 @@ contains
          write (unit, '(A, ES0.4)') '  d2qdr2 = ', d2qdr2
          write (unit, '(A, ES0.4)') '  d2psidr2 = ', d2psidr2
          write (unit, '(A, I0)') '  nzed_local = ', nzed_local
-         write (unit, '(A, L0)') '  read_profile_variation = ', read_profile_variation
-         write (unit, '(A, L0)') '  write_profile_variation = ', write_profile_variation
+         write (unit, '(A, L1)') '  read_profile_variation = ', read_profile_variation
+         write (unit, '(A, L1)') '  write_profile_variation = ', write_profile_variation
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
       
@@ -588,8 +588,8 @@ contains
          write (unit, '(A, I0)') '  z_grid_refinement_factor = ', z_grid_refinement_factor 
          write (unit, '(A, I0)') '  surface_option = ', surface_option 
          write (unit, '(A, I0)') '  n_tolerated_test_arrays_inconsistencies = ', n_tolerated_test_arrays_inconsistencies
-         write (unit, '(A, L0)') '  verbose = ', verbose
-         write (unit, '(A, L0)') '  rectangular_cross_section = ', rectangular_cross_section
+         write (unit, '(A, L1)') '  verbose = ', verbose
+         write (unit, '(A, L1)') '  rectangular_cross_section = ', rectangular_cross_section
          write (unit, '(A, A, A)') '  radial_coordinate = "', trim(radial_coordinate),'"'
          write (unit, '(A)') '/'
          write (unit, '(A)') ''

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_initialise_distribution_function.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_initialise_distribution_function.f90
@@ -192,7 +192,7 @@ contains
          write (unit, '(A)') '&initialise_distribution'
          write (unit, '(A, A, A)') '  initialise_distribution_option = "', trim(initialise_distribution_option),'"'
          write (unit, '(A, ES0.4)') '  phiinit = ', phiinit
-         write (unit, '(A, L0)') '  scale_to_phiinit = ', scale_to_phiinit
+         write (unit, '(A, L1)') '  scale_to_phiinit = ', scale_to_phiinit
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
       
@@ -268,10 +268,10 @@ contains
          write (unit, '(A, ES0.4)') '  width0 = ', width0
          write (unit, '(A, ES0.4)') '  den0 = ', den0
          write (unit, '(A, ES0.4)') '  upar0 = ', upar0
-         write (unit, '(A, L0)') '  oddparity = ', oddparity
-         write (unit, '(A, L0)') '  left = ', left
-         write (unit, '(A, L0)') '  chop_side = ', chop_side
-         write (unit, '(A, L0)') '  set_theta0_to_zero = ', set_theta0_to_zero
+         write (unit, '(A, L1)') '  oddparity = ', oddparity
+         write (unit, '(A, L1)') '  left = ', left
+         write (unit, '(A, L1)') '  chop_side = ', chop_side
+         write (unit, '(A, L1)') '  set_theta0_to_zero = ', set_theta0_to_zero
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
       
@@ -342,8 +342,8 @@ contains
          write (unit, '(A)') '&initialise_distribution_noise'
          write (unit, '(A, ES0.4)') '  zf_init = ', zf_init
          write (unit, '(A, I0)') '  rng_seed = ', rng_seed
-         write (unit, '(A, L0)') '  left = ', left
-         write (unit, '(A, L0)') '  chop_side = ', chop_side
+         write (unit, '(A, L1)') '  left = ', left
+         write (unit, '(A, L1)') '  chop_side = ', chop_side
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
       
@@ -442,8 +442,8 @@ contains
          write (unit, '(A, ES0.4)') '  upar2 = ', upar2
          write (unit, '(A, ES0.4)') '  tpar2 = ', tpar2
          write (unit, '(A, ES0.4)') '  tperp2 = ', tperp2
-         write (unit, '(A, L0)') '  left = ', left
-         write (unit, '(A, L0)') '  chop_side = ', chop_side
+         write (unit, '(A, L1)') '  left = ', left
+         write (unit, '(A, L1)') '  chop_side = ', chop_side
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
       
@@ -586,7 +586,7 @@ contains
          write (unit, '(A, A, A)') '  restart_dir = "', trim(restart_dir),'"'
          write (unit, '(A, ES0.4)') '  tstart = ', tstart
          write (unit, '(A, ES0.4)') '  scale = ', scale
-         write (unit, '(A, L0)') '  save_many = ', save_many
+         write (unit, '(A, L1)') '  save_many = ', save_many
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
         

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_kxky_grid.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_kxky_grid.f90
@@ -301,10 +301,10 @@ contains
          write (unit, '(A, I0)') '  jtwist = ', jtwist
          write (unit, '(A, ES0.4)') '  jtwistfac = ', jtwistfac
          write (unit, '(A, ES0.4)') '  phase_shift_angle = ', phase_shift_angle
-         write (unit, '(A, L0)') '  centered_in_rho = ', centered_in_rho
-         write (unit, '(A, L0)') '  periodic_variation = ', periodic_variation
-         write (unit, '(A, L0)') '  randomize_phase_shift = ', randomize_phase_shift
-         write (unit, '(A, L0)') '  periodic_variation = ', periodic_variation
+         write (unit, '(A, L1)') '  centered_in_rho = ', centered_in_rho
+         write (unit, '(A, L1)') '  periodic_variation = ', periodic_variation
+         write (unit, '(A, L1)') '  randomize_phase_shift = ', randomize_phase_shift
+         write (unit, '(A, L1)') '  periodic_variation = ', periodic_variation
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
          
@@ -313,7 +313,7 @@ contains
          write (unit, '(A, I0)') '  naky = ', naky
          write (unit, '(A, I0)') '  ikx_max = ', ikx_max
          write (unit, '(A, I0)') '  naky_all = ', naky_all
-         write (unit, '(A, L0)') '  reality = ', reality
+         write (unit, '(A, L1)') '  reality = ', reality
          write (unit, '(A, I0)') '  nalpha = ', nalpha
          write (unit, '(A)') '/'
          write (unit, '(A)') ''

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_neoclassical_input.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_neoclassical_input.f90
@@ -140,7 +140,7 @@ contains
 
          write (unit, '(A)') '&neoclassical_input'
          write (unit, '(A, A, A)') '  neo_option = "', trim(neo_option),'"'
-         write (unit, '(A, L0)') '  include_neoclassical_terms = ', include_neoclassical_terms
+         write (unit, '(A, L1)') '  include_neoclassical_terms = ', include_neoclassical_terms
          write (unit, '(A, I0)') '  nradii = ', nradii
          write (unit, '(A, ES0.4)') '  drho = ', drho
          write (unit, '(A)') '/'

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_numerical_parameters.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_numerical_parameters.f90
@@ -159,7 +159,7 @@ contains
          write (unit, '(A)') '&time_trace_options'
          write (unit, '(A, I0)') '  nstep = ', nstep
          write (unit, '(A, F0.4)') '  tend = ', tend
-         write (unit, '(A, L0)') '  autostop = ', autostop
+         write (unit, '(A, L1)') '  autostop = ', autostop
          write (unit, '(A, ES0.4)') '  avail_cpu_time = ', avail_cpu_time
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
@@ -371,20 +371,20 @@ contains
 
          write (unit, '(A)') '&numerical_algorithms'
          write (unit, '(A, A, A)') '  explicit_algorithm = "', trim(explicit_algorithm), '"'
-         write (unit, '(A, L0)') '  flip_flop = ', flip_flop
-         write (unit, '(A, L0)') '  stream_implicit = ', stream_implicit
-         write (unit, '(A, L0)') '  stream_iterative_implicit = ', stream_iterative_implicit
-         write (unit, '(A, L0)') '  stream_matrix_inversion = ', stream_matrix_inversion
-         write (unit, '(A, L0)') '  driftkinetic_implicit = ', driftkinetic_implicit
-         write (unit, '(A, L0)') '  mirror_implicit = ', mirror_implicit
-         write (unit, '(A, L0)') '  mirror_semi_lagrange = ', mirror_semi_lagrange
-         write (unit, '(A, L0)') '  mirror_linear_interp = ', mirror_linear_interp
-         write (unit, '(A, L0)') '  drifts_implicit = ', drifts_implicit
-         write (unit, '(A, L0)') '  fully_implicit = ', fully_implicit
-         write (unit, '(A, L0)') '  fully_explicit = ', fully_explicit
-         write (unit, '(A, L0)') '  maxwellian_inside_zed_derivative = ', maxwellian_inside_zed_derivative
-         write (unit, '(A, L0)') '  use_deltaphi_for_response_matrix = ', use_deltaphi_for_response_matrix
-         write (unit, '(A, L0)') '  split_parallel_dynamics = ', split_parallel_dynamics
+         write (unit, '(A, L1)') '  flip_flop = ', flip_flop
+         write (unit, '(A, L1)') '  stream_implicit = ', stream_implicit
+         write (unit, '(A, L1)') '  stream_iterative_implicit = ', stream_iterative_implicit
+         write (unit, '(A, L1)') '  stream_matrix_inversion = ', stream_matrix_inversion
+         write (unit, '(A, L1)') '  driftkinetic_implicit = ', driftkinetic_implicit
+         write (unit, '(A, L1)') '  mirror_implicit = ', mirror_implicit
+         write (unit, '(A, L1)') '  mirror_semi_lagrange = ', mirror_semi_lagrange
+         write (unit, '(A, L1)') '  mirror_linear_interp = ', mirror_linear_interp
+         write (unit, '(A, L1)') '  drifts_implicit = ', drifts_implicit
+         write (unit, '(A, L1)') '  fully_implicit = ', fully_implicit
+         write (unit, '(A, L1)') '  fully_explicit = ', fully_explicit
+         write (unit, '(A, L1)') '  maxwellian_inside_zed_derivative = ', maxwellian_inside_zed_derivative
+         write (unit, '(A, L1)') '  use_deltaphi_for_response_matrix = ', use_deltaphi_for_response_matrix
+         write (unit, '(A, L1)') '  split_parallel_dynamics = ', split_parallel_dynamics
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
 

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_parallelisation.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_parallelisation.f90
@@ -163,9 +163,9 @@ contains
          write (unit, '(A, A, A)') '  xyzs_layout = "', trim(xyzs_layout), '"'
          write (unit, '(A, A, A)') '  vms_layout = "', trim(vms_layout), '"'
          write (unit, '(A, A, A)') '  kymus_layout = "', trim(kymus_layout), '"'
-         write (unit, '(A, L0)') '  fields_kxkyz = ', fields_kxkyz
-         write (unit, '(A, L0)') '  mat_gen = ', mat_gen
-         write (unit, '(A, L0)') '  mat_read = ', mat_read
+         write (unit, '(A, L1)') '  fields_kxkyz = ', fields_kxkyz
+         write (unit, '(A, L1)') '  mat_gen = ', mat_gen
+         write (unit, '(A, L1)') '  mat_read = ', mat_read
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
 

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_physics_parameters.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_physics_parameters.f90
@@ -194,17 +194,17 @@ contains
 
          write (unit, '(A)') '&gyrokinetic_terms'
          write (unit, '(A, A, A)') '  simulation_domain = "', trim(simulation_domain), '"'
-         write (unit, '(A, L0)') '  include_parallel_streaming = ', include_parallel_streaming
-         write (unit, '(A, L0)') '  include_mirror = ', include_mirror
-         write (unit, '(A, L0)') '  include_xdrift = ', include_xdrift
-         write (unit, '(A, L0)') '  include_ydrift = ', include_ydrift
-         write (unit, '(A, L0)') '  include_drive = ', include_drive
-         write (unit, '(A, L0)') '  include_nonlinear = ', include_nonlinear
-         write (unit, '(A, L0)') '  include_parallel_nonlinearity = ', include_parallel_nonlinearity
-         write (unit, '(A, L0)') '  include_electromagnetic = ', include_electromagnetic
-         write (unit, '(A, L0)') '  include_flow_shear = ', include_flow_shear
-         write (unit, '(A, L0)') '  include_full_flux_annulus = ', include_full_flux_annulus
-         write (unit, '(A, L0)') '  include_radial_variation = ', include_radial_variation
+         write (unit, '(A, L1)') '  include_parallel_streaming = ', include_parallel_streaming
+         write (unit, '(A, L1)') '  include_mirror = ', include_mirror
+         write (unit, '(A, L1)') '  include_xdrift = ', include_xdrift
+         write (unit, '(A, L1)') '  include_ydrift = ', include_ydrift
+         write (unit, '(A, L1)') '  include_drive = ', include_drive
+         write (unit, '(A, L1)') '  include_nonlinear = ', include_nonlinear
+         write (unit, '(A, L1)') '  include_parallel_nonlinearity = ', include_parallel_nonlinearity
+         write (unit, '(A, L1)') '  include_electromagnetic = ', include_electromagnetic
+         write (unit, '(A, L1)') '  include_flow_shear = ', include_flow_shear
+         write (unit, '(A, L1)') '  include_full_flux_annulus = ', include_full_flux_annulus
+         write (unit, '(A, L1)') '  include_radial_variation = ', include_radial_variation
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
 
@@ -300,7 +300,7 @@ contains
          !-------------------------------------------------------------------------
 
          write (unit, '(A)') '&scale_gyrokinetic_terms'
-         write (unit, '(A, L0)') '  suppress_zonal_interaction = ', suppress_zonal_interaction
+         write (unit, '(A, L1)') '  suppress_zonal_interaction = ', suppress_zonal_interaction
          write (unit, '(A, F0.2)') '  xdriftknob = ', xdriftknob
          write (unit, '(A, F0.2)') '  ydriftknob = ', ydriftknob
          write (unit, '(A, F0.2)') '  wstarknob = ', wstarknob
@@ -390,8 +390,8 @@ contains
          !-------------------------------------------------------------------------
 
          write (unit, '(A)') '&electromagnetic'
-         write (unit, '(A, L0)') '  include_apar = ', include_apar
-         write (unit, '(A, L0)') '  include_bpar = ', include_bpar
+         write (unit, '(A, L1)') '  include_apar = ', include_apar
+         write (unit, '(A, L1)') '  include_bpar = ', include_bpar
          write (unit, '(A, ES0.4)') '  beta = ', beta
          write (unit, '(A)') '/'
          write (unit, '(A)') ''

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_radial_variation.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_radial_variation.f90
@@ -249,19 +249,19 @@ contains
          write (unit, '(A, A, A)') '  lr_debug_option = "', lr_debug_option, '"'
          write (unit, '(A, A, A)') '  krook_option = "', krook_option, '"'
          write (unit, '(A, A, A)') '  zf_option = "', zf_option, '"'
-         write (unit, '(A, L0)') '  ky_solve_real = ', ky_solve_real
+         write (unit, '(A, L1)') '  ky_solve_real = ', ky_solve_real
          write (unit, '(A, I0)') '  ky_solve_radial = ', ky_solve_radial
-         write (unit, '(A, L0)') '  include_pressure_variation = ', include_pressure_variation
-         write (unit, '(A, L0)') '  include_geometric_variation = ', include_geometric_variation
-         write (unit, '(A, L0)') '  smooth_zf = ', smooth_zf
-         write (unit, '(A, L0)') '  rk_step = ', rk_step
+         write (unit, '(A, L1)') '  include_pressure_variation = ', include_pressure_variation
+         write (unit, '(A, L1)') '  include_geometric_variation = ', include_geometric_variation
+         write (unit, '(A, L1)') '  smooth_zf = ', smooth_zf
+         write (unit, '(A, L1)') '  rk_step = ', rk_step
          write (unit, '(A, ES0.4)') '  nu_krook_mb = ', nu_krook_mb
          write (unit, '(A, I0)') '  mb_debug_step = ', mb_debug_step
          write (unit, '(A, ES0.4)') '  krook_exponent = ', krook_exponent
          write (unit, '(A, ES0.4)') '  krook_efold = ', krook_efold
          write (unit, '(A, ES0.4)') '  phi_bound = ', phi_bound
          write (unit, '(A, ES0.4)') '  phi_pow = ', phi_pow
-         write (unit, '(A, L0)') '  use_dirichlet_bc = ', use_dirichlet_bc
+         write (unit, '(A, L1)') '  use_dirichlet_bc = ', use_dirichlet_bc
          write (unit, '(A, I0)') '  boundary_size = ', boundary_size
          write (unit, '(A, I0)') '  krook_size = ', krook_size
          write (unit, '(A)') '/'
@@ -398,13 +398,13 @@ contains
          write (unit, '(A, ES0.4)') '  nu_krook = ', nu_krook
          write (unit, '(A, ES0.4)') '  tcorr_source = ', tcorr_source
          write (unit, '(A, I0)') '  ikxmax_source = ', ikxmax_source
-         write (unit, '(A, L0)') '  krook_odd = ', krook_odd
-         write (unit, '(A, L0)') '  exclude_boundary_regions = ', exclude_boundary_regions
+         write (unit, '(A, L1)') '  krook_odd = ', krook_odd
+         write (unit, '(A, L1)') '  exclude_boundary_regions = ', exclude_boundary_regions
          write (unit, '(A, ES0.4)') '  tcorr_source_qn = ', tcorr_source_qn
-         write (unit, '(A, L0)') '  exclude_boundary_regions_qn = ', exclude_boundary_regions_qn
-         write (unit, '(A, L0)') '  from_zero = ', from_zero
-         write (unit, '(A, L0)') '  conserve_momentum = ', conserve_momentum
-         write (unit, '(A, L0)') '  conserve_density = ', conserve_density
+         write (unit, '(A, L1)') '  exclude_boundary_regions_qn = ', exclude_boundary_regions_qn
+         write (unit, '(A, L1)') '  from_zero = ', from_zero
+         write (unit, '(A, L1)') '  conserve_momentum = ', conserve_momentum
+         write (unit, '(A, L1)') '  conserve_density = ', conserve_density
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
 

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_species.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_species.f90
@@ -620,7 +620,8 @@ contains
 
       ! Variables that are read from the input file
       integer, intent(out) :: nradii
-      character(*), intent(out) :: data_file
+      ! Local fixed-length string for the namelist
+      character(len=256), intent(out) :: data_file
       
       !-------------------------------------------------------------------------
       

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_species.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_species.f90
@@ -234,8 +234,8 @@ contains
          write (unit, '(A)') '&species_options'
          write (unit, '(A, I0)') '  nspec = ', nspec
          write (unit, '(A, A, A)') '  species_option = "', trim(species_option), '"'
-         write (unit, '(A, L0)') '  read_profile_variation = ', read_profile_variation
-         write (unit, '(A, L0)') '  write_profile_variation = ', write_profile_variation
+         write (unit, '(A, L1)') '  read_profile_variation = ', read_profile_variation
+         write (unit, '(A, L1)') '  write_profile_variation = ', write_profile_variation
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
 

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_velocity_grids.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_velocity_grids.f90
@@ -107,8 +107,8 @@ contains
          write (unit, '(A, I0)') '  nmu = ', nmu
          write (unit, '(A, F0.2)') '  vpa_max = ', vpa_max
          write (unit, '(A, F0.2)') '  vperp_max = ', vperp_max
-         write (unit, '(A, L0)') '  equally_spaced_mu_grid = ', equally_spaced_mu_grid
-         write (unit, '(A, L0)') '  conservative_wgts_vpa = ', conservative_wgts_vpa
+         write (unit, '(A, L1)') '  equally_spaced_mu_grid = ', equally_spaced_mu_grid
+         write (unit, '(A, L1)') '  conservative_wgts_vpa = ', conservative_wgts_vpa
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
 

--- a/STELLA_CODE/read_namelists_from_input_file/namelist_z_grid.f90
+++ b/STELLA_CODE/read_namelists_from_input_file/namelist_z_grid.f90
@@ -167,7 +167,7 @@ contains
          write (unit, '(A, I0)') '  nzed = ', nzed
          write (unit, '(A, I0)') '  nperiod = ', nperiod
          write (unit, '(A, I0)') '  ntubes = ', ntubes
-         write (unit, '(A, L0)') '  zed_equal_arc = ', zed_equal_arc
+         write (unit, '(A, L1)') '  zed_equal_arc = ', zed_equal_arc
          write (unit, '(A)') '/'
          write (unit, '(A)') ''
 


### PR DESCRIPTION
This MR introduces some changes that were necessary to make things compile using the CMake -> ifx toolchain. 

The changes are basically:
- Printing the booleans requires to specify the size to be non-zero `L0` -> `L1`. (This is okay for most compilers, `ifx` is here a bit tighter and follows the standard more strict)
-  make namelist-group-object a non-variable length string. Here apparently `ifx` is also a bit stricter than other compilers

With these changes it works for me in MN5: 
```
---------------------------------
 stella Configuration Summary
---------------------------------

 LAPACK support           : ON
 FFTW support             : ON
 NetCDF support           : ON
 Default real kind        : double
 POSIX support            : OFF
 Use F2003/8 intrinsics   : ON
 Compilation flags        :  -O2 -g
 Build type               : RelWithDebInfo
 Compiler                 : /gpfs/apps/MN5/GPP/ONEAPI/2025.1/compiler/latest/bin/ifx
 ```
 
 ```
[100%] Linking Fortran executable stella
Create symbolic link to stella in the directory above COMPILATION/build_cmake
Create symbolic link to stella in the directory above COMPILATION
[100%] Built target stella
```